### PR TITLE
FontAwesome の導入

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,12 +15,6 @@
  */
 // Sprockets で Bootstrap を扱うためにインクルード
 @import "bootstrap/scss/bootstrap";
-// FontAwesome を扱うためにインクルード
-$fa-font-path: '@fortawesome/fontawesome-free/webfonts';
-@import '@fortawesome/fontawesome-free/scss/fontawesome';
-@import '@fortawesome/fontawesome-free/scss/solid';
-@import '@fortawesome/fontawesome-free/scss/regular';
-@import '@fortawesome/fontawesome-free/scss/brands';
 
 body {
   margin: 0;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,6 @@ import "channels"
 
 // Bootstrap をインクルード
 import "bootstrap/dist/js/bootstrap"
-import "@fortawesome/fontawesome-free/js/all"
 import "./preview"
 
 Rails.start()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "moknow",
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.4",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,11 +885,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@fortawesome/fontawesome-free@^5.15.4":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
-  integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
-
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"


### PR DESCRIPTION
close #63 
  
## 実装内容
- `@fortawesome/fontawesome-free` をインストール
- Javascript と stylesheets.scss でインポート
  
## 動作確認
- [x] アイコンが作成できること(確認後アイコンは削除)
- [x] `rubocop -a`を実行
- [x] `bundle exec rails_best_practices .`を実行