### PR TITLE
ナビゲーションバーの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,7 +24,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 
 body {
   margin: 0;
-  padding-top: 56px;
+  padding: 56px 0;
   background-color: #EEEDEC;
 }
 
@@ -56,9 +56,9 @@ span.description {
   @extend .alert-danger;
 }
 
-button.close {
-  outline: none;
-}
+button.close, button.navbar-toggler {
+    outline: none;
+  }
 
 #preview {
   height: 200px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 
 body {
   margin: 0;
+  padding-top: 56px;
   background-color: #EEEDEC;
 }
 

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,6 +1,8 @@
 <h1>MOKNOW</h1>
-<%= link_to "会員登録", new_user_registration_path, class: 'btn btn-info' %>
-<%= link_to "ログイン", new_user_session_path, class: 'btn btn-info' %>
+<% unless user_signed_in? %>
+  <%= link_to "会員登録", new_user_registration_path, class: 'btn btn-info' %>
+  <%= link_to "ログイン", new_user_session_path, class: 'btn btn-info' %>
+<% end %>
   <h2>Feature</h2>
   <p>アプリについて</p>
   <div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -30,6 +30,26 @@
           <i class="fas fa-sign-out-alt"></i> ログアウト
         <% end %>
       </div>
+    <% else %>
+      <div class="navbar-nav ml-auto">
+        <%= link_to "#", class: "nav-item nav-link" do %>
+          <i class="fas fa-id-card-alt"></i> ゲストログイン
+        <% end %>
+        <%= link_to new_user_registration_path, class: "nav-item nav-link" do %>
+          <i class="fas fa-user-plus"></i> 会員登録
+        <% end %>
+        <%= link_to new_user_session_path, class: "nav-item nav-link" do %>
+          <i class="fas fa-sign-in-alt"></i> ログイン
+        <% end %>
+        <div class="d-sm-none">
+          <%= link_to "#", class: "nav-item nav-link" do %>
+            <i class="fas fa-chart-pie"></i> データ
+          <% end %>
+          <%= link_to "#", class: "nav-item nav-link" do %>
+            <i class="fas fa-book"></i> ノウハウ
+          <% end %>
+        </div>
+      </div>
     <% end %>
   </div>
 </nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -20,14 +20,14 @@
         <%= link_to "#", class: "nav-item nav-link" do %>
           <i class="fas fa-book"></i> ノウハウ
         <% end %>
-        <%= link_to "#", class: "nav-item nav-link" do %>
-          <i class="fas fa-home"></i> タイムライン
-        <% end %>
-        <%= link_to "#", class: "nav-item nav-link" do %>
-          <i class="fas fa-user"></i> マイページ
-        <% end %>
         <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか?"}, class: "nav-item nav-link" do %>
           <i class="fas fa-sign-out-alt"></i> ログアウト
+        <% end %>
+        <%= link_to "#", class: "nav-item nav-link d-sm-block d-none" do %>
+          <i class="fas fa-home"></i> タイムライン
+        <% end %>
+        <%= link_to "#", class: "nav-item nav-link d-sm-block d-none" do %>
+          <i class="fas fa-user"></i> マイページ
         <% end %>
       </div>
     <% else %>
@@ -41,15 +41,35 @@
         <%= link_to new_user_session_path, class: "nav-item nav-link" do %>
           <i class="fas fa-sign-in-alt"></i> ログイン
         <% end %>
-        <div class="d-sm-none">
-          <%= link_to "#", class: "nav-item nav-link" do %>
-            <i class="fas fa-chart-pie"></i> データ
-          <% end %>
-          <%= link_to "#", class: "nav-item nav-link" do %>
-            <i class="fas fa-book"></i> ノウハウ
-          <% end %>
-        </div>
+        <%= link_to "#", class: "nav-item nav-link d-sm-none" do %>
+          <i class="fas fa-chart-pie"></i> データ
+        <% end %>
+        <%= link_to "#", class: "nav-item nav-link d-sm-none" do %>
+          <i class="fas fa-book"></i> ノウハウ
+        <% end %>
       </div>
     <% end %>
   </div>
 </nav>
+
+<% if user_signed_in? %>
+<nav class="navbar navbar-expand navbar-light bg-light fixed-bottom d-sm-none">
+  <div class="navbar-nav w-100 justify-content-between">
+    <button type="button" class="btn btn-info">
+      <i class="fas fa-plus-square"></i>
+    </button>
+    <button type="button" class="btn btn-outline-secondary">
+      <i class="fas fa-search"></i>
+    </button>
+    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
+      <i class="fas fa-couch"></i>
+    <% end %>
+    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
+      <i class="fas fa-home"></i>
+    <% end %>
+    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
+      <i class="fas fa-user"></i>
+    <% end %>
+  </div>
+</nav>
+<% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,35 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+  <%= link_to "MOKNOW", root_path, class: "navbar-brand" %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <% if user_signed_in? %>
+      <button type="button" class="btn btn-info">
+        <i class="fas fa-plus-square"></i> 投稿する
+      </button>
+      <button type="button" class="btn btn-outline-secondary">
+        <i class="fas fa-search"></i> 検索する
+      </button>
+      <%# 要素を右寄せで配置 %>
+      <div class="navbar-nav ml-auto">
+        <%= link_to "#", class: "nav-item nav-link" do %>
+          <i class="fas fa-chart-pie"></i> データ
+        <% end %>
+        <%= link_to "#", class: "nav-item nav-link" do %>
+          <i class="fas fa-book"></i> ノウハウ
+        <% end %>
+        <%= link_to "#", class: "nav-item nav-link" do %>
+          <i class="fas fa-home"></i> タイムライン
+        <% end %>
+        <%= link_to "#", class: "nav-item nav-link" do %>
+          <i class="fas fa-user"></i> マイページ
+        <% end %>
+        <%= link_to destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか?"}, class: "nav-item nav-link" do %>
+          <i class="fas fa-sign-out-alt"></i> ログアウト
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</nav>

--- a/app/views/layouts/_header_bottom.html.erb
+++ b/app/views/layouts/_header_bottom.html.erb
@@ -1,0 +1,21 @@
+<% if user_signed_in? %>
+<nav class="navbar navbar-expand navbar-light bg-light fixed-bottom d-sm-none">
+  <div class="navbar-nav w-100 justify-content-between">
+    <button type="button" class="btn btn-info">
+      <i class="fas fa-plus-square"></i>
+    </button>
+    <button type="button" class="btn btn-outline-secondary">
+      <i class="fas fa-search"></i>
+    </button>
+    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
+      <i class="fas fa-couch"></i>
+    <% end %>
+    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
+      <i class="fas fa-home"></i>
+    <% end %>
+    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
+      <i class="fas fa-user"></i>
+    <% end %>
+  </div>
+</nav>
+<% end %>

--- a/app/views/layouts/_header_top.html.erb
+++ b/app/views/layouts/_header_top.html.erb
@@ -51,25 +51,3 @@
     <% end %>
   </div>
 </nav>
-
-<% if user_signed_in? %>
-<nav class="navbar navbar-expand navbar-light bg-light fixed-bottom d-sm-none">
-  <div class="navbar-nav w-100 justify-content-between">
-    <button type="button" class="btn btn-info">
-      <i class="fas fa-plus-square"></i>
-    </button>
-    <button type="button" class="btn btn-outline-secondary">
-      <i class="fas fa-search"></i>
-    </button>
-    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
-      <i class="fas fa-couch"></i>
-    <% end %>
-    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
-      <i class="fas fa-home"></i>
-    <% end %>
-    <%= link_to "#", class: "nav-item nav-link fa-lg" do %>
-      <i class="fas fa-user"></i>
-    <% end %>
-  </div>
-</nav>
-<% end %>

--- a/app/views/layouts/_header_top.html.erb
+++ b/app/views/layouts/_header_top.html.erb
@@ -6,10 +6,10 @@
 
   <div class="collapse navbar-collapse" id="navbarNav">
     <% if user_signed_in? %>
-      <button type="button" class="btn btn-info">
+      <button type="button" class="btn btn-info d-sm-inline d-none">
         <i class="fas fa-plus-square"></i> 投稿する
       </button>
-      <button type="button" class="btn btn-outline-secondary">
+      <button type="button" class="btn btn-outline-secondary d-sm-inline d-none">
         <i class="fas fa-search"></i> 検索する
       </button>
       <%# 要素を右寄せで配置 %>
@@ -41,10 +41,10 @@
         <%= link_to new_user_session_path, class: "nav-item nav-link" do %>
           <i class="fas fa-sign-in-alt"></i> ログイン
         <% end %>
-        <%= link_to "#", class: "nav-item nav-link d-sm-none" do %>
+        <%= link_to "#", class: "nav-item nav-link" do %>
           <i class="fas fa-chart-pie"></i> データ
         <% end %>
-        <%= link_to "#", class: "nav-item nav-link d-sm-none" do %>
+        <%= link_to "#", class: "nav-item nav-link" do %>
           <i class="fas fa-book"></i> ノウハウ
         <% end %>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,8 @@
   </head>
 
   <body>
-    <%= render 'layouts/header' %>
+    <%= render 'layouts/header_top' %>
+    <%= render 'layouts/header_bottom' %>
     <%= render 'layouts/flash_messages' %>
     <div class='base-container py-4 <%= max_width %>'>
       <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <%= render 'layouts/header' %>
     <%= render 'layouts/flash_messages' %>
     <div class='base-container py-4 <%= max_width %>'>
       <%= yield %>


### PR DESCRIPTION
close #8 
  
## 実装内容
- Bootstrap を使用したナビバーを作成
  - _header_top.html.erb 、_header_bottom.html.erb のファイルを作成して、部分テンプレート化
- _header_top.html.erb
  - 上に固定
  - lg 以下で折りたたむように設定(ハンバーガーメニュー)
  - sm 以下では `投稿`, `検索`, `タイムライン`,  `マイページ`を非表示
- _header_bottom.html.erb
  - sm 以下の場合のみ表示
  - 下に固定
  - 折りたたみは無し
  - `投稿`, `検索`, `タイムライン`,  `マイページ`を常に表示
  
## 動作確認
- [x] ローカル環境での動作確認
- [x] Heroku のステージング環境での動作確認
- [x] `rubocop -a` を実行
- [x] `rails_best_practices .`を実行