### PR TITLE
Post モデルのテスト(モデルスペック)

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  activerecord:
+    model:
+      post: 投稿
+    attributes:
+      post:
+        content: 投稿内容
+        likes_count: いいね数
+        marks_count: マーク数
+        user: ユーザー

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :post do
-    content { 'MyText' }
-    likes_count { 1 }
-    marks_count { 1 }
-    user { nil }
+    content { Faker::Lorem.paragraph }
+    likes_count { rand(0..100) }
+    marks_count { rand(0..100) }
+    user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     address { rand(1..47) }
     household { rand(1..6) }
     profile { Faker::Lorem.sentence }
-    avater { Rack::Test::UploadedFile.new(Rails.root.join('images/fallback/default.png')) }
+    avater { Rack::Test::UploadedFile.new(Rails.root.join('public/images/fallback/default.png')) }
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Post, type: :model do
         expect(subject).to eq true
       end
     end
+
     # content のバリデーションテスト
     context 'content が空のとき' do
       let(:post) { build(:post, content: '') }
@@ -19,8 +20,9 @@ RSpec.describe Post, type: :model do
         # expect { subject }.to raise_error 'バリデーションに失敗しました: 投稿内容を入力してください'
       end
     end
+
     context 'content が 2001 文字以上のとき' do
-      let(:post) { build(:post, content: "a" * 2001) }
+      let(:post) { build(:post, content: 'a' * 2001) }
       it 'エラーが発生すること' do
         expect(subject).to eq false
         expect(post.errors.messages[:content]).to include 'は2000文字以内で入力してください'

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,5 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    subject { post.valid? }
+
+    context 'データが条件を満たすとき' do
+      let(:post) { build(:post) }
+      it '保存できること' do
+        expect(subject).to eq true
+      end
+    end
+    # content のバリデーションテスト
+    context 'content が空のとき' do
+      let(:post) { build(:post, content: '') }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post.errors.messages[:content]).to include 'を入力してください'
+        # expect { subject }.to raise_error 'バリデーションに失敗しました: 投稿内容を入力してください'
+      end
+    end
+    context 'content が 2001 文字以上のとき' do
+      let(:post) { build(:post, content: "a" * 2001) }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post.errors.messages[:content]).to include 'は2000文字以内で入力してください'
+        # expect { subject }.to raise_error 'バリデーションに失敗しました: 投稿内容は2000文字以内で入力してください'
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe User, type: :model do
 
     # avater のバリデーションテスト
     context 'avater の画像サイズが 5MB 以上のとき' do
-      let(:user) { build(:user, avater: Rack::Test::UploadedFile.new(Rails.root.join('images/fallback/rspec_size_test.jpg'))) }
+      let(:user) { build(:user, avater: Rack::Test::UploadedFile.new(Rails.root.join('public/images/fallback/rspec_size_test.jpg'))) }
       it 'エラーが発生する' do
         expect(subject).to eq false
         expect(user.errors.messages[:avater]).to include 'ファイルを5MBバイト以下のサイズにしてください'
@@ -147,7 +147,7 @@ RSpec.describe User, type: :model do
     end
 
     context 'avater の拡張子が .jpeg .jpg .png 以外のとき' do
-      let(:user) { build(:user, avater: Rack::Test::UploadedFile.new(Rails.root.join('images/fallback/rspec_extension_test.tiff'))) }
+      let(:user) { build(:user, avater: Rack::Test::UploadedFile.new(Rails.root.join('public/images/fallback/rspec_extension_test.tiff'))) }
       it 'エラーが発生する' do
         expect(subject).to eq false
         expect(user.errors.messages[:avater]).to include '"tiff"ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: jpg, jpeg, png'


### PR DESCRIPTION
close #41 
  
## 実装内容
- `factory_bot_rails` を使用して初期データを作成
- `content` のバリデーションエラーテスト
  - 空文字でエラーが発生すること
  - 2001 文字以上でエラーが発生する事
  
- User モデルの `avatar` 画像取得パスの修正
  
## 動作確認
- [x] `bundle exec rspec` を実行
- [x] `rubocop -a`を実行
- [x] `bundle exec rails_best_practices .`を実行