### PR TITLE
Photo モデル・テーブルを作成

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,0 +1,4 @@
+class Photo < ApplicationRecord
+  belongs_to :post
+  validates :image, presence: true
+end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,5 +1,5 @@
 class Photo < ApplicationRecord
   belongs_to :post
   validates :image, presence: true
-  mount_upoader :image, ImageUploader
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,4 +1,5 @@
 class Photo < ApplicationRecord
   belongs_to :post
   validates :image, presence: true
+  mount_upoader :image, ImageUploader
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
   belongs_to :user
+  has_many :photos, dependent: :destory
   validates :content, presence: true, length: { maximum: 2000 }
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,52 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # ファイル形式のバリデーション
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+  # ファイルサイズのバリデーション
+  def size_range
+    0..5.megabytes
+  end
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -37,7 +37,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # For images you might use something like this:
   # ファイル形式のバリデーション
   def extension_allowlist
-    %w(jpg jpeg gif png)
+    %w[jpg jpeg png]
   end
 
   # Override the filename of the uploaded files:

--- a/db/migrate/20210816075818_create_photos.rb
+++ b/db/migrate/20210816075818_create_photos.rb
@@ -1,0 +1,10 @@
+class CreatePhotos < ActiveRecord::Migration[6.1]
+  def change
+    create_table :photos do |t|
+      t.string :image, null: false
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_14_235139) do
+ActiveRecord::Schema.define(version: 2021_08_16_075818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 2021_08_14_235139) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "photos", force: :cascade do |t|
+    t.string "image", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_photos_on_post_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -56,5 +64,6 @@ ActiveRecord::Schema.define(version: 2021_08_14_235139) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "photos", "posts"
   add_foreign_key "posts", "users"
 end

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :photo do
+    image { "MyString" }
+    post { nil }
+  end
+end

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :photo do
-    image { "MyString" }
+    image { 'MyString' }
     post { nil }
   end
 end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Photo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #67 
  
## 実装内容
- テーブルに`image`カラムを作成
- バリデーションを設定
  - 空文字禁止
  - ファイルサイズ上限を 5MB
  - ファイル形式を `.png`、`.jpg`、`.jpeg`に制限
- Post モデルと関連付け
- `image`カラムと連携するために、image_uploader ファイルを作成