### PR TITLE
投稿詳細ページを実装

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the posts controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+img.details-image {
+  object-fit: contain;
+  max-height: 600px;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -2,7 +2,15 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
-img.details-image {
+.details-image {
   object-fit: contain;
   max-height: 600px;
+}
+
+.details-card {
+  max-height: 600px;
+}
+
+.details-content {
+  height: 80%;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,9 @@ class PostsController < ApplicationController
     @posts = Post.includes(:photos).order(created_at: :desc)
   end
 
-  def show; end
+  def show
+    @post = Post.find(params[:id])
+  end
 
   def create
     post = PostForm.new(post_params.merge(current_user_id: current_user.id))

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,4 +2,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :photos, dependent: :destroy
   validates :content, presence: true, length: { maximum: 2000 }
+
+# user モデルの name を委譲する
+  delegate :name, :avater, to: :user, prefix: true
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,9 @@
 <hr class="devise-link mt-0 mb-4">
 
 <% @posts.each do |post| %>
-  <%= image_tag post.photos.first.image.url %>
+  <%= link_to post do %>
+    <%= image_tag post.photos.first.image.url %>
+  <% end %>
   <p><%= post.content %></p>
   <hr class="devise-link mt-0 mb-4">
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,8 +5,8 @@
     </div>
     <div class="col-md-6 details-card">
         <div class="card-header">
-          <%= image_tag @post.user.avater.url, class: "rounded-circle", size: "32x32" %>
-          <%= @post.user.name %>
+          <%= image_tag @post.user_avater.url, class: "rounded-circle", size: "32x32" %>
+          <%= @post.user_name %>
           <div class="dropdown float-right">
             <div class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="fas fa-cog"></i>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,9 +3,25 @@
     <div class="col-md-6 d-flex align-items-center justify-content-center">
       <%= image_tag @post.photos.first.image.url, class: "img-fluid details-image" %>
     </div>
-    <div class="col-md-6">
-      <div class="card-body">
-        <p class="card-text"><%= simple_format(h @post.content) %></p>
+    <div class="col-md-6 details-card">
+        <div class="card-header">
+          <%= image_tag @post.user.avater.url, class: "rounded-circle", size: "32x32" %>
+          <%= @post.user.name %>
+          <div class="dropdown float-right">
+            <div class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <i class="fas fa-cog"></i>
+            </div>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu2">
+              <button class="dropdown-item btn btn-light" type="button">編集</button>
+              <button class="dropdown-item btn btn-light" type="button">削除</button>
+            </div>
+          </div>
+        </div>
+      <div class="card-body overflow-auto details-content">
+        <%= simple_format(h @post.content) %>
+      </div>
+      <div class="card-body border-top">
+        コメント欄を追加
       </div>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,2 +1,12 @@
-<h1>Posts#show</h1>
-<p>Find me in app/views/posts/show.html.erb</p>
+<div class="card mb-6 border-0">
+  <div class="row no-gutters">
+    <div class="col-md-6 d-flex align-items-center justify-content-center">
+      <%= image_tag @post.photos.first.image.url, class: "img-fluid details-image" %>
+    </div>
+    <div class="col-md-6">
+      <div class="card-body">
+        <p class="card-text"><%= simple_format(h @post.content) %></p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
close #7 
  
## 実装内容
- 投稿詳細に対する`アバター画像`、`ユーザー名`、`投稿画像` を表示
  - 投稿内容はスクロールで表示
  - `アバター画像`、`ユーザー名`は `delegate`を使用して Post モデルに設定
  - コメント欄は別タスクで実装
- 投稿の`編集`, `削除`ボタンを作成(機能実装は別タスクとする)
  
## 動作確認
- [x] ローカル環境での動作確認
- [x] `rubocop -a`と`bundle exec rails_best_practices .` を実行