### PR TITLE
画像を複数投稿できるように修正

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -2,8 +2,11 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+.carousel-item {
+  text-align: center;
+}
+
 .details-image {
-  object-fit: contain;
   max-height: 600px;
 }
 

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -47,3 +47,10 @@
   height: 100%;
   object-fit: cover;
 }
+
+.delete-preview {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  opacity: 0.7;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -32,3 +32,18 @@
 		bottom: 0;
   }
 }
+
+.preview-item {
+  position:relative;
+  width: calc(100% / 2);
+  padding-top: calc(100% / 2);
+}
+
+.preview-image {
+  position: absolute;
+  top: 0;
+  padding: 3px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -37,6 +37,7 @@
   position:relative;
   width: calc(100% / 2);
   padding-top: calc(100% / 2);
+  height: 0;
 }
 
 .preview-image {
@@ -53,4 +54,24 @@
   top: 0.5rem;
   right: 0.5rem;
   opacity: 0.7;
+}
+
+#drop-container {
+  position:relative;
+  width: calc(100% / 2);
+  padding-top: calc((100% / 2) - 4px );
+  margin: 0;
+  background: #f7f7f7;
+  border: 2px dashed #9c9c9c;
+  cursor: pointer;
+}
+
+#drop-container-icon {
+  position: absolute;
+  width: 25%;
+  height: 25%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #9c9c9c;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -2,6 +2,15 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+.carousel-indicators {
+  .indicators-icon {
+    border-radius: 50%;
+    margin: 1px 3px;
+    height: 5px;
+    width: 5px;
+  }
+}
+
 .carousel-item {
   text-align: center;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -47,10 +47,3 @@
   height: 100%;
   object-fit: cover;
 }
-
-.delete-preview {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  opacity: 0.7;
-}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,8 +10,8 @@ class PostsController < ApplicationController
   end
 
   def create
-    post = Post.new
-    post_form = PostForm.new(post_params.merge(current_user_id: current_user.id, post: post))
+    @post = Post.new
+    post_form = PostForm.new(post_params.merge(current_user_id: current_user.id, post: @post))
     if post_form.save
       redirect_to posts_path, notice: '投稿しました'
     else
@@ -40,6 +40,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post_form).permit(:content, :image)
+    params.require(:post_form).permit(:content, image: [])
   end
 end

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -21,7 +21,9 @@ class PostForm
         # 投稿を作成して、画像を保存
         @post = Post.new(content: content, user_id: current_user_id)
       end
-      @post.photos.build(image: image).save!
+      image.each do |image|
+        @post.photos.build(image: image).save!
+      end
     end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ import "bootstrap/dist/js/bootstrap"
 // FontAwesome をインクルード
 import "@fortawesome/fontawesome-free/js/all"
 import "./preview"
+import "./post_preview"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -6,19 +6,21 @@ $(document).on('turbolinks:load', function () {
     let file_field = document.querySelector('input[type=file]')
     //file_field の値が変更されたときに発火するイベント
     $('#post-preview-image').on("change", function(){
-
+      
       // 選択をキャンセルした場合の処理
       if ($(this).val() === "") {
         $('#preview-box').children().remove();
         file_field.files = dataBox.files
         dataBox.clearData();
       }
-
+      
       // 選択したfileのオブジェクトをpropで取得
       let files = $('input[type="file"]').prop('files')[0];
       $.each(this.files, function(i, file){
         let fileReader = new FileReader();
-        
+        // 選択したfileのオブジェクトにidを付与
+        dataBox.files.length === 0 ? (preview_item_number = 0) : (preview_item_number = dataBox.files[dataBox.files.length - 1].id);
+        file.id = preview_item_number + 1;
         // DataTransferオブジェクトに対して、fileを追加
         dataBox.items.add(file)
         // DataTransferオブジェクトに入ったfile一覧をfile_fieldの中に代入
@@ -38,12 +40,34 @@ $(document).on('turbolinks:load', function () {
 
         // 読み込んだ URL を src に格納して プレビューの HTML を作成
         fileReader.onloadend = function() {
-          let html = `<div class="preview-item" data-image="${file.name}">
+          let html = `<div class="preview-item" data-id="${file.id}">
                         <img src="${fileReader.result}" class="preview-image">
-                      </div>`
+                        <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>
+                      </div>`;
           $('#preview-box').append($(html));
         };
       });
+    });
+
+    // プレビューの削除ボタンをクリックしたとき、発火するイベント
+    $(document).on("click", '.delete-preview', function(){
+      let target_image = $(this).parents('.preview-item');
+      let target_id = $(target_image).data('id');
+      $.each(file_field.files, function(i, file){
+        if( file.id === target_id ){
+          dataBox.items.remove(i);
+          return false;
+        }
+      })
+      file_field.files = dataBox.files;
+      target_image.remove();
+      // 削除後の画像の枚数によって form の表示を変更
+      if ( file_field.files.length <= 6 ){
+        $('#new-button').prop('disabled', false);
+        if ( file_field.files.length <= 5 ){
+          $('#post-preview-image').show();
+        }
+      }
     });
   });
 });

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -23,30 +23,27 @@ $(document).on('turbolinks:load', function () {
         dataBox.items.add(file)
         // DataTransferオブジェクトに入ったfile一覧をfile_fieldの中に代入
         file_field.files = dataBox.files
-        
+
         fileReader.readAsDataURL(file);
+
+        // 画像が6枚以上になった場合、input を非表示
+        let preview_item_length = $('.preview-item').length + i +1;
+        if ( preview_item_length >= 6 ){
+          $('#post-preview-image').hide();
+          if ( preview_item_length == 7 ){
+            $('#new-button').prop('disabled', true);
+            alert('画像は最大 6枚 にしてください');
+          } 
+        }
+
         // 読み込んだ URL を src に格納して プレビューの HTML を作成
         fileReader.onloadend = function() {
           let html = `<div class="preview-item" data-image="${file.name}">
                         <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-dark btn-sm delete-preview rounded-circle"><i class="fas fa-times"></i></button>
                       </div>`
           $('#preview-box').append($(html));
         };
       });
-
-      // プレビューの削除ボタンをクリックしたとき、発火するイベント
-      $(document).on("click", '.delete-preview', function(){
-        let target_preview = $(this).parents('.preview-item')
-        let target_image = $(target_preview).data('image')
-        $.each(file_field.files, function(i, file){
-          if( file.name === target_image ){
-            dataBox.items.remove(i)
-          }
-        });
-        target_preview.remove();
-        file_field.files = dataBox.files
-      })
     });
   });
 });

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -9,7 +9,7 @@ $(document).on('turbolinks:load', function () {
       
       // 選択をキャンセルした場合の処理
       if ($(this).val() === "") {
-        $('#preview-box').children().remove();
+        $('.preview-item').remove();
         file_field.files = dataBox.files
         dataBox.clearData();
       }
@@ -31,11 +31,11 @@ $(document).on('turbolinks:load', function () {
         // 画像が6枚以上になった場合、input を非表示
         let previewItemLength = $('.preview-item').length + i +1;
         if ( previewItemLength >= 6 ){
-          $('#post-preview-image').hide();
+          $('#drop-container').hide();
           if ( previewItemLength == 7 ){
             $('#new-button').prop('disabled', true);
             alert('画像は最大 6枚 にしてください');
-          } 
+          }
         }
 
         // 読み込んだ URL を src に格納して プレビューの HTML を作成
@@ -44,7 +44,7 @@ $(document).on('turbolinks:load', function () {
                         <img src="${fileReader.result}" class="preview-image">
                         <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>
                       </div>`;
-          $('#preview-box').append($(html));
+          $('#drop-container').before($(html));
         };
       });
     });
@@ -65,9 +65,52 @@ $(document).on('turbolinks:load', function () {
       if ( file_field.files.length <= 6 ){
         $('#new-button').prop('disabled', false);
         if ( file_field.files.length <= 5 ){
-          $('#post-preview-image').show();
+          $('#drop-container').show();
         }
       }
+    });
+
+    let dropArea = document.getElementById('drop-container');
+    //ドロップエリアの上にある時に発火するイベント
+    dropArea.addEventListener("dragover", function(e){
+      e.preventDefault();
+      $(this).css({'border': '2px solid #9e9e9e', 'opacity': '0.5'});
+    },false);
+    //ドロップエリアから離れた時に発火するイベント
+    dropArea.addEventListener("dragleave", function(e){
+      e.preventDefault();
+      $(this).css({'border': '2px dashed #9c9c9c', 'background': '#f7f7f7'});
+    },false);
+    // ドロップしたときに発火するイベント
+    dropArea.addEventListener("drop", function(e) {
+      e.preventDefault();
+      $(this).css({'border': '2px dashed #9c9c9c', 'background': '#f7f7f7'});
+      var files = e.dataTransfer.files;
+      $.each(files, function(i, file){
+        let fileReader = new FileReader();
+        let lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
+        file.id = lastFileId + 1;
+        dataBox.items.add(file)
+        file_field.files = dataBox.files
+        fileReader.readAsDataURL(file);
+        // 画像が6枚以上になった場合、input を非表示
+        let previewItemLength = $('.preview-item').length + i +1;
+        if ( previewItemLength >= 6 ){
+          $('#drop-container').hide();
+          if ( previewItemLength == 7 ){
+            $('#new-button').prop('disabled', true);
+            alert('画像は最大 6枚 にしてください');
+          }
+        }
+        // 読み込んだ URL を src に格納して プレビューの HTML を作成
+        fileReader.onloadend = function() {
+          let html = `<div class="preview-item" data-id="${file.id}">
+                        <img src="${fileReader.result}" class="preview-image">
+                        <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>
+                      </div>`;
+          $('#drop-container').before($(html));
+        };
+      });
     });
   });
 });

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -1,9 +1,9 @@
 $(document).on('turbolinks:load', function () {
   $(function(){
     //DataTransferオブジェクトで、データを格納する箱を作る
-    var dataBox = new DataTransfer();
+    let dataBox = new DataTransfer();
     //querySelectorでfile_fieldを取得
-    var file_field = document.querySelector('input[type=file]')
+    let file_field = document.querySelector('input[type=file]')
     //file_field の値が変更されたときに発火するイベント
     $('#post-preview-image').on("change", function(){
 
@@ -15,9 +15,9 @@ $(document).on('turbolinks:load', function () {
       }
 
       // 選択したfileのオブジェクトをpropで取得
-      var files = $('input[type="file"]').prop('files')[0];
+      let files = $('input[type="file"]').prop('files')[0];
       $.each(this.files, function(i, file){
-        var fileReader = new FileReader();
+        let fileReader = new FileReader();
         
         // DataTransferオブジェクトに対して、fileを追加
         dataBox.items.add(file)
@@ -27,7 +27,7 @@ $(document).on('turbolinks:load', function () {
         fileReader.readAsDataURL(file);
         // 読み込んだ URL を src に格納して プレビューの HTML を作成
         fileReader.onloadend = function() {
-          var html = `<div class="preview-item" data-image="${file.name}">
+          let html = `<div class="preview-item" data-image="${file.name}">
                         <img src="${fileReader.result}" class="preview-image">
                         <button type="button" class="btn btn-dark btn-sm delete-preview rounded-circle"><i class="fas fa-times"></i></button>
                       </div>`

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -29,10 +29,10 @@ $(document).on('turbolinks:load', function () {
         fileReader.readAsDataURL(file);
 
         // 画像が6枚以上になった場合、input を非表示
-        let preview_item_length = $('.preview-item').length + i +1;
-        if ( preview_item_length >= 6 ){
+        let previewItemLength = $('.preview-item').length + i +1;
+        if ( previewItemLength >= 6 ){
           $('#post-preview-image').hide();
-          if ( preview_item_length == 7 ){
+          if ( previewItemLength == 7 ){
             $('#new-button').prop('disabled', true);
             alert('画像は最大 6枚 にしてください');
           } 
@@ -51,16 +51,16 @@ $(document).on('turbolinks:load', function () {
 
     // プレビューの削除ボタンをクリックしたとき、発火するイベント
     $(document).on("click", '.delete-preview', function(){
-      let target_image = $(this).parents('.preview-item');
-      let target_id = $(target_image).data('id');
+      let targetImage = $(this).parents('.preview-item');
+      let targetId = $(targetImage).data('id');
       $.each(file_field.files, function(i, file){
-        if( file.id === target_id ){
+        if( file.id === targetId ){
           dataBox.items.remove(i);
           return false;
         }
       })
       file_field.files = dataBox.files;
-      target_image.remove();
+      targetImage.remove();
       // 削除後の画像の枚数によって form の表示を変更
       if ( file_field.files.length <= 6 ){
         $('#new-button').prop('disabled', false);

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -19,8 +19,8 @@ $(document).on('turbolinks:load', function () {
       $.each(this.files, function(i, file){
         let fileReader = new FileReader();
         // 選択したfileのオブジェクトにidを付与
-        dataBox.files.length === 0 ? (preview_item_number = 0) : (preview_item_number = dataBox.files[dataBox.files.length - 1].id);
-        file.id = preview_item_number + 1;
+        let lastFileId = dataBox.files.length === 0 ? 0 : $(dataBox.files).last()[0].id;
+        file.id = lastFileId + 1;
         // DataTransferオブジェクトに対して、fileを追加
         dataBox.items.add(file)
         // DataTransferオブジェクトに入ったfile一覧をfile_fieldの中に代入

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -1,0 +1,41 @@
+$(document).on('turbolinks:load', function () {
+  $(function(){
+    //DataTransferオブジェクトで、データを格納する箱を作る
+    var dataBox = new DataTransfer();
+    //querySelectorでfile_fieldを取得
+    var file_field = document.querySelector('input[type=file]')
+    //file_field の値が変更されたときに発火するイベント
+    $('#post-preview-image').on("change", function(){
+
+      // 選択をキャンセルした場合の処理
+      if ($(this).val() === "") {
+        $('#preview-box').children().remove();
+        file_field.files = dataBox.files
+        dataBox.clearData();
+      }
+
+      // 選択したfileのオブジェクトをpropで取得
+      var files = $('input[type="file"]').prop('files')[0];
+      $.each(this.files, function(i, file){
+        // Fileオブジェクトを読み込む
+        var fileReader = new FileReader();
+        
+        // DataTransferオブジェクトに対して、fileを追加
+        dataBox.items.add(file)
+        // DataTransferオブジェクトに入ったfile一覧をfile_fieldの中に代入
+        file_field.files = dataBox.files
+        
+        fileReader.readAsDataURL(file);
+
+        // 読み込んだ URL を src に格納して プレビューの HTML を作成
+        fileReader.onloadend = function() {
+          var html= `<div class="preview-item">
+          <img src="${fileReader.result}" class="preview-image">
+          </div>`
+          $('#preview-box').append($(html));
+        };
+      });
+
+    });
+  });
+});

--- a/app/javascript/packs/post_preview.js
+++ b/app/javascript/packs/post_preview.js
@@ -17,7 +17,6 @@ $(document).on('turbolinks:load', function () {
       // 選択したfileのオブジェクトをpropで取得
       var files = $('input[type="file"]').prop('files')[0];
       $.each(this.files, function(i, file){
-        // Fileオブジェクトを読み込む
         var fileReader = new FileReader();
         
         // DataTransferオブジェクトに対して、fileを追加
@@ -26,16 +25,28 @@ $(document).on('turbolinks:load', function () {
         file_field.files = dataBox.files
         
         fileReader.readAsDataURL(file);
-
         // 読み込んだ URL を src に格納して プレビューの HTML を作成
         fileReader.onloadend = function() {
-          var html= `<div class="preview-item">
-          <img src="${fileReader.result}" class="preview-image">
-          </div>`
+          var html = `<div class="preview-item" data-image="${file.name}">
+                        <img src="${fileReader.result}" class="preview-image">
+                        <button type="button" class="btn btn-dark btn-sm delete-preview rounded-circle"><i class="fas fa-times"></i></button>
+                      </div>`
           $('#preview-box').append($(html));
         };
       });
 
+      // プレビューの削除ボタンをクリックしたとき、発火するイベント
+      $(document).on("click", '.delete-preview', function(){
+        let target_preview = $(this).parents('.preview-item')
+        let target_image = $(target_preview).data('image')
+        $.each(file_field.files, function(i, file){
+          if( file.name === target_image ){
+            dataBox.items.remove(i)
+          }
+        });
+        target_preview.remove();
+        file_field.files = dataBox.files
+      })
     });
   });
 });

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,7 +1,7 @@
 class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   storage :file
@@ -32,6 +32,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   # version :thumb do
   #   process resize_to_fit: [50, 50]
   # end
+
+  process resize_to_fill: [1080, 1080]
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <div class="card mb-6 border-0">
   <div class="row no-gutters">
-    <div class="col-md-6 d-flex align-items-center justify-content-center">
+    <div class="col-md-6">
       <%= image_tag @post.photos.first.image.url, class: "img-fluid details-image" %>
     </div>
     <div class="col-md-6">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,7 @@
 <div class="card mb-6 border-0">
   <div class="row no-gutters">
     <%# 投稿画像を表示 %>
-    <div class="col-md-6 carousel slide" id="carouselExampleIndicators" date-interval="false">
+    <div class="col-md-6 carousel slide" id="carouselExampleIndicators" data-interval="false">
       <% i = 0 %>
       <% if @post.photos.length > 1 %>
         <ol class="carousel-indicators">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,8 +1,35 @@
 <div class="card mb-6 border-0">
   <div class="row no-gutters">
-    <div class="col-md-6">
-      <%= image_tag @post.photos.first.image.url, class: "img-fluid details-image" %>
+    <%# 投稿画像を表示 %>
+    <div class="col-md-6 carousel slide" id="carouselExampleIndicators" date-interval="false">
+      <ol class="carousel-indicators">
+        <% i = 0 %>
+        <% while i < @post.photos.length %>
+          <li data-target="#carouselExampleIndicators" data-slide-to="<%= i %>" class="<%= "active" if i == 0 %>"></li>
+          <% i += 1 %>
+        <% end %>
+      </ol>
+      <div class="carousel-inner">
+        <% @post.photos.each_with_index do |photo, i| %>
+          <% if i == 0 %>
+            <div class="carousel-item active">
+          <% else %>
+            <div class="carousel-item">
+          <% end %>
+              <%= image_tag photo.image.url, class: "img-fluid details-image"%>
+            </div>
+        <% end %>
+      </div>
+      <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="sr-only">Previous</span>
+      </a>
+      <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="sr-only">Next</span>
+      </a>
     </div>
+    <%# 投稿詳細を表示 %>
     <div class="col-md-6">
       <div class="card-body h-100">
         <div class="card-name">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,13 +2,15 @@
   <div class="row no-gutters">
     <%# 投稿画像を表示 %>
     <div class="col-md-6 carousel slide" id="carouselExampleIndicators" date-interval="false">
-      <ol class="carousel-indicators">
-        <% i = 0 %>
-        <% while i < @post.photos.length %>
-          <li data-target="#carouselExampleIndicators" class="indicators-icon" data-slide-to="<%= i %>" class="<%= "active" if i == 0 %>"></li>
-          <% i += 1 %>
-        <% end %>
-      </ol>
+      <% i = 0 %>
+      <% if @post.photos.length > 1 %>
+        <ol class="carousel-indicators">
+          <% while i < @post.photos.length %>
+            <li data-target="#carouselExampleIndicators" class="indicators-icon" data-slide-to="<%= i %>" class="<%= "active" if i == 0 %>"></li>
+            <% i += 1 %>
+          <% end %>
+        </ol>
+      <% end %>
       <div class="carousel-inner">
         <% @post.photos.each_with_index do |photo, i| %>
           <% if i == 0 %>
@@ -20,14 +22,16 @@
             </div>
         <% end %>
       </div>
-      <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
-        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-        <span class="sr-only">Previous</span>
-      </a>
-      <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
-        <span class="carousel-control-next-icon" aria-hidden="true"></span>
-        <span class="sr-only">Next</span>
-      </a>
+      <% if @post.photos.length > 1 %>
+        <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="sr-only">Previous</span>
+        </a>
+        <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="sr-only">Next</span>
+        </a>
+      <% end %>
     </div>
     <%# 投稿詳細を表示 %>
     <div class="col-md-6">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,7 +5,7 @@
       <ol class="carousel-indicators">
         <% i = 0 %>
         <% while i < @post.photos.length %>
-          <li data-target="#carouselExampleIndicators" data-slide-to="<%= i %>" class="<%= "active" if i == 0 %>"></li>
+          <li data-target="#carouselExampleIndicators" class="indicators-icon" data-slide-to="<%= i %>" class="<%= "active" if i == 0 %>"></li>
           <% i += 1 %>
         <% end %>
       </ol>

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -4,7 +4,7 @@
   </div>
   <small>2000文字以内で入力してください</small>
   <div class="form-group mt-3">
-    <%= form.file_field :image, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true %>
+    <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true %>
   </div>
   <div class="form-group mt-3">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -4,7 +4,7 @@
   </div>
   <small>2000文字以内で入力してください</small>
   <div class="form-group mt-3">
-    <%= form.file_field :image, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true %>
+    <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true %>
   </div>
   <div class="form-group mt-3">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -5,10 +5,14 @@
   <small>* 2000文字以内で入力してください *</small>
   <hr>
   <div class="form-group mt-3">
-    <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true, id: "post-preview-image", type: "file" %>
+    <div id="preview-box" class="d-flex flex-wrap">
+      <label id="drop-container">
+        <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true, id: "post-preview-image", type: "file", style: 'display: none;' %>
+        <i class="far fa-image" id="drop-container-icon" ></i>
+      </label>
+    </div>
   </div>
   <small>* 最大6枚まで投稿できます *</small>
-  <div id="preview-box" class="d-flex flex-wrap"></div>
   <div class="form-group mt-3">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>
   </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -4,8 +4,9 @@
   </div>
   <small>2000文字以内で入力してください</small>
   <div class="form-group mt-3">
-    <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true %>
+    <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true, id: "post-preview-image", type: "file" %>
   </div>
+  <div id="preview-box" class="d-flex flex-wrap"></div>
   <div class="form-group mt-3">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>
   </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -2,10 +2,12 @@
   <div class="form-group mt-3">
     <%= form.text_area :content, class: 'form-control', rows: '10', maxlength: 2000, required: true %>
   </div>
-  <small>2000文字以内で入力してください</small>
+  <small>* 2000文字以内で入力してください *</small>
+  <hr>
   <div class="form-group mt-3">
     <%= form.file_field :image, multiple: true, class: 'form-control-file', accept: 'image/png, image/jpeg, image/jpg', required: true, id: "post-preview-image", type: "file" %>
   </div>
+  <small>* 最大6枚まで投稿できます *</small>
   <div id="preview-box" class="d-flex flex-wrap"></div>
   <div class="form-group mt-3">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>


### PR DESCRIPTION
close #87

## 実装内容
- フォームで複数画像選択できるように修正
- `minimagick`を使用して`1080 x 1080`にリサイズして保存
- 詳細ページでは Bootstrap の Carousel を使用して表示
  - 複数プレビューを表示
  - 1枚の場合はコントローラとインジケータは表示しない
- 投稿枚数は `最大6枚`に設定
- 画像ごとの削除ボタンを実装
- ドロップでの投稿機能を実装
  
## 動作確認
- [x] ローカル環境での動作確認
- [x] `rubocop -a`を実行
- [x] `bundle exec rails_best_practices .`を実行