### PR TITLE
カテゴリー機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,6 +42,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post_form).permit(:content, image: [], tag_ids: [])
+    params.require(:post_form).permit(:content, image: [], tag_ids: [], category_ids: [])
   end
 end

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -1,7 +1,7 @@
 class PostForm
   include ActiveModel::Model
 
-  attr_accessor :content, :image, :current_user_id, :post, :tag_ids
+  attr_accessor :content, :image, :current_user_id, :post, :tag_ids, :category_ids
 
   # Post モデルのバリデーション
   validates :content, presence: true, length: { maximum: 2000 }
@@ -26,6 +26,9 @@ class PostForm
       end
       tag_ids.each do |tag_id|
         @post.post_tags.build(tag_id: tag_id).save!
+      end
+      category_ids.each do |category_id|
+        @post.post_categories.build(category_id: category_id).save!
       end
     end
   end

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -12,7 +12,7 @@ class PostForm
     # バリデーションチェック
     return false if invalid?
 
-    # 投稿が存在する場合、投稿内容とその画像を更新
+    # 投稿が存在する場合は、投稿内容を更新
     ActiveRecord::Base.transaction do
       if @post.persisted?
         @post.photos.delete_all
@@ -21,15 +21,21 @@ class PostForm
         # 投稿を作成して、画像を保存
         @post = Post.new(content: content, user_id: current_user_id)
       end
-      image.each do |image|
-        @post.photos.build(image: image).save!
-      end
-      tag_ids.each do |tag_id|
-        @post.post_tags.build(tag_id: tag_id).save!
-      end
-      category_ids.each do |category_id|
-        @post.post_categories.build(category_id: category_id).save!
-      end
+      build_attrbutes
+    end
+  end
+
+  private
+
+  def build_attrbutes
+    image.each do |image|
+      @post.photos.build(image: image).save!
+    end
+    tag_ids.each do |tag_id|
+      @post.post_tags.build(tag_id: tag_id).save!
+    end
+    category_ids.each do |category_id|
+      @post.post_categories.build(category_id: category_id).save!
     end
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,5 @@
 class Category < ApplicationRecord
-  validates :categories, presence: true
+  has_many :post_categories, dependent: :destroy
+  has_many :posts, through: :post_categories
+  validates :name, presence: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,8 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
+  has_many :post_categories, dependent: :destroy
+  has_many :categories, through: :post_categories
 
   # user モデルの name を委譲する
   delegate :name, :avater, to: :user, prefix: true

--- a/app/models/post_category.rb
+++ b/app/models/post_category.rb
@@ -1,0 +1,5 @@
+class PostCategory < ApplicationRecord
+  belongs_to :post
+  belongs_to :category
+  validates :post_id, uniqueness: { scope: :category_id }
+end

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -13,14 +13,24 @@
               <%= image_tag post.user_avater.url, class: "rounded-circle", size: "32x32" %>
               <%= post.user_name %>
             </div>
-            <div class="border-top py-3">
-              <i class="fas fa-tag"></i>
-              <% post.tags.each do |tag| %>
-                <span class="pr-2">
-                  <%= tag.name %>
-                </span>
-              <% end %>
-            </div>
+            <small>
+              <div class="border-top pt-2">
+                <i class="fas fa-tag"></i>
+                <% post.tags.each do |tag| %>
+                  <span class="pr-2">
+                    <%= tag.name %>
+                  </span>
+                <% end %>
+              </div>
+              <div class="pt-2">
+                <i class="fas fa-folder"></i>
+                <% post.categories.each do |category| %>
+                  <span class="pr-2">
+                    <%= category.name %>
+                  </span>
+                <% end %>
+              </div>
+            </small>
             <p class="card-text text-truncate pt-3">
               <%= post.content %>
             </p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -55,11 +55,19 @@
             </div>
           <% end %>
         </div>
-        <div class="border-top py-3">
+        <div class="border-top pt-3">
           <i class="fas fa-tag"></i>
           <% @post.tags.each do |tag| %>
             <span class="pr-2">
               <%= tag.name %>
+            </span>
+          <% end %>
+        </div>
+        <div class="pt-3">
+          <i class="fas fa-folder"></i>
+          <% @post.categories.each do |category| %>
+            <span class="pr-2">
+              <%= category.name %>
             </span>
           <% end %>
         </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -28,6 +28,15 @@
   </div>
   <small>* タグは3つまで選択可能です *</small>
   <hr>
+  <div class="form-group row mt-3">
+    <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
+      <div class="form-check col-6 col-md-4 col-lg-2 flex-wrap">
+        <%= form.check_box %>
+        <%= form.text %>
+      </div>
+    <% end %>
+  </div>
+  <hr>
   <div class="form-group mt-4">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>
   </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -14,19 +14,14 @@
   </div>
   <small>* 最大6枚まで投稿できます *</small>
   <hr>
-  <div class="form-row">
-    <div class="form-group mt-3">
-      <div class="form-check form-check-inline flex-wrap m-0">
-        <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
-          <div class="col-6 col-md-4 col-lg-2">
-            <%= form.check_box %>
-            <%= form.text %>
-          </div>
-        <% end %>
+  <div class="form-group row mt-3">
+    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
+      <div class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
+        <%= form.check_box %>
+        <%= form.text %>
       </div>
-    </div>
+    <% end %>
   </div>
-  <small>* タグは3つまで選択可能です *</small>
   <hr>
   <div class="form-group row mt-3">
     <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>

--- a/db/migrate/20210929173450_create_post_categories.rb
+++ b/db/migrate/20210929173450_create_post_categories.rb
@@ -1,0 +1,11 @@
+class CreatePostCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :post_categories do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_categories, [:post_id, :category_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_28_042403) do
+ActiveRecord::Schema.define(version: 2021_09_29_173450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,16 @@ ActiveRecord::Schema.define(version: 2021_09_28_042403) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["post_id"], name: "index_photos_on_post_id"
+  end
+
+  create_table "post_categories", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id", "category_id"], name: "index_post_categories_on_post_id_and_category_id", unique: true
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
 
   create_table "post_tags", force: :cascade do |t|
@@ -87,6 +97,8 @@ ActiveRecord::Schema.define(version: 2021_09_28_042403) do
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "photos", "posts"
+  add_foreign_key "post_categories", "categories"
+  add_foreign_key "post_categories", "posts"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ household = 'two_person_household'
 image = File.open(Rails.root.join('public/images/fallback/test.png'))
 content = 'コメント内容を表示します'
 tags = ['キッチン', 'リビング', 'バス', 'トイレ', 'バルコニー', '洗面台', '寝室', '洋室', '和室', '子供部屋', '玄関', 'その他']
+categories = ['成功', '失敗', 'おすすめ', 'DIY', '紹介', 'その他']
 
 User.find_or_create_by!(email: email) do |user|
   user.name = name
@@ -31,6 +32,12 @@ tags.each do |tag|
   Tag.create!(name: tag)
 end
 puts 'タグの初期データインポートに成功しました。'
+
+ActiveRecord::Base.connection.execute('TRUNCATE TABLE categories RESTART IDENTITY CASCADE')
+categories.each do |category|
+  Category.create!(name: category)
+end
+puts 'カテゴリーの初期データインポートに成功しました。'
 
 # テスト投稿の初期データ
 ActiveRecord::Base.connection.execute('TRUNCATE TABLE posts RESTART IDENTITY CASCADE')
@@ -56,3 +63,9 @@ post1.post_tags.create!(tag_id: 1)
 post2.post_tags.create!(tag_id: 2)
 post3.post_tags.create!(tag_id: 3)
 puts '投稿タグの初期データインポートに成功しました。'
+
+ActiveRecord::Base.connection.execute('TRUNCATE TABLE post_tags RESTART IDENTITY CASCADE')
+post1.post_categories.create!(category_id: 1)
+post2.post_categories.create!(category_id: 2)
+post3.post_categories.create!(category_id: 3)
+puts '投稿カテゴリーの初期データインポートに成功しました。'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,7 +64,7 @@ post2.post_tags.create!(tag_id: 2)
 post3.post_tags.create!(tag_id: 3)
 puts '投稿タグの初期データインポートに成功しました。'
 
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE post_tags RESTART IDENTITY CASCADE')
+ActiveRecord::Base.connection.execute('TRUNCATE TABLE post_categories RESTART IDENTITY CASCADE')
 post1.post_categories.create!(category_id: 1)
 post2.post_categories.create!(category_id: 2)
 post3.post_categories.create!(category_id: 3)

--- a/spec/factories/post_categories.rb
+++ b/spec/factories/post_categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post_category do
+    post { nil }
+    category { nil }
+  end
+end

--- a/spec/models/post_category_spec.rb
+++ b/spec/models/post_category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PostCategory, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #92
   
## 実装内容
- `PostCategory`モデルを作成
  - `Post`モデルと`Category`モデルを関連付け
- 新規投稿時にカテゴリー選択機能を実装
- タイムラインの各投稿に`カテゴリー`を表示
- 投稿詳細ページに`カテゴリー`を表示
- `FormObject`の処理を修正
- `カテゴリー`の初期データを作成
- `タグ`の投稿フォームを`カテゴリー`と同じスタイルに修正
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行 