### PR TITLE
検索機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'gon'
 gem 'kaminari'
 gem 'mini_magick'
 gem 'rails-i18n', '~> 6.0'
+gem 'ransack'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -343,6 +347,7 @@ DEPENDENCIES
   rails (~> 6.1.4)
   rails-i18n (~> 6.0)
   rails_best_practices
+  ransack
   rspec-rails
   rubocop-performance
   rubocop-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -68,3 +68,20 @@ button.close, button.navbar-toggler {
 a:hover {
   text-decoration: none;
 }
+
+.tag-color {
+  color: #baa877;
+}
+
+.category-color {
+  color: #a8a9a8;
+}
+
+.form-check label {
+  cursor: pointer;
+}
+
+input:checked + span {
+  color: #EEEDEC;
+  background-color: #6c757d;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!, if: :controller_name?
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_search
 
   def controller_name?
     true unless controller_name == 'homes'
@@ -9,5 +10,10 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:avater, :name, :age, :address, :household])
     devise_parameter_sanitizer.permit(:account_update, keys: [:avater, :name, :age, :address, :household, :favorite_items, :profile])
+  end
+
+  def set_search
+    @q = Post.ransack(params[:q])
+    @posts = @q.result.includes(:photos).order(created_at: :desc)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,7 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[update destroy]
 
-  def index
-  end
+  def index; end
 
   def show
     @post = Post.find(params[:id])

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,6 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[update destroy]
 
   def index
-    @posts = Post.includes(:photos).order(created_at: :desc)
   end
 
   def show

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,6 +21,7 @@ import "./jquery.validate"
 import "./jquery.validate.min"
 import "./validate_rules"
 import "./user_show"
+import "./search"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/search.js
+++ b/app/javascript/packs/search.js
@@ -1,0 +1,9 @@
+$(document).on('turbolinks:load', function(){
+  $(function(){
+    $('#reset-button').on('click', function(){
+      $('input[type="search"]').val('');
+      $('input[name="q[tags_id_in][]"]').prop('checked', false);
+      $('input[name="q[categories_id_in][]"]').prop('checked', false);
+    });
+  });
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,8 @@
   <body>
     <%= render 'shared/header_top' %>
     <%= render 'shared/header_bottom' %>
+    <%= render 'shared/modal', action: 'new', title: '新規登録' %>
+    <%= render 'shared/modal', action: 'search', title: '検索' %>
     <div id="flash-messages">
       <%= render 'layouts/flash_messages' %>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,26 @@
-<div class="title-group">
-  <h1>Time Line</h1>
-  <p class="sub-title mb-0">タイムライン</p>
-</div>
-<hr class="devise-link mt-0 mb-5">
-<div class="row">
-  <%= render partial: "time_line", collection: @posts, as: "post" %>
-</div>
+<% if @posts.present? %>
+  <div class="title-group">
+    <h1>Time Line</h1>
+    <p class="sub-title mb-0">タイムライン</p>
+  </div>
+  <hr class="devise-link mt-0 mb-5">
+  <div class="row">
+    <%= render partial: "time_line", collection: @posts, as: "post" %>
+  </div>
+<% elsif @posts.blank? && Post.exists? %>
+  <h3 class="d-flex justify-content-center pt-5">検索結果が見つかりませんでした</h3>
+  <div class="d-flex justify-content-center py-2">
+    <button type="button" class="btn btn-outline-secondary btn-sm" data-toggle="modal" data-target="#search-modal">
+      <i class="fas fa-search"></i><p class="d-sm-inline d-none"> 検索する</p>
+    </button>
+    <span>から別のキーワードを検索してください</span>
+  </div>
+<% else %>
+  <h3 class="d-flex justify-content-center pt-5">投稿がまだありません</h3>
+  <div class="d-flex justify-content-center py-2 flex-wrap">
+    <button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#new-modal">
+      <i class="fas fa-plus-square"></i><p class="d-sm-inline d-none"> 投稿する</p>
+    </button>
+    <span class="d-flex align-items-center ml-1">から新しい投稿をしてみよう！</span>
+  </div>
+<% end %>

--- a/app/views/shared/_header_bottom.html.erb
+++ b/app/views/shared/_header_bottom.html.erb
@@ -1,10 +1,10 @@
 <% if user_signed_in? %>
 <nav class="navbar navbar-expand navbar-light bg-light fixed-bottom d-sm-none">
   <div class="navbar-nav w-100 justify-content-between">
-    <button type="button" class="btn btn-info">
+    <button type="button" class="btn btn-info" data-toggle="modal" data-target="#new-modal">
       <i class="fas fa-plus-square"></i>
     </button>
-    <button type="button" class="btn btn-outline-secondary">
+    <button type="button" class="btn btn-outline-secondary" data-toggle="modal" data-target="#search-modal">
       <i class="fas fa-search"></i>
     </button>
     <%= link_to "#", class: "nav-item nav-link fa-lg" do %>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -9,7 +9,7 @@
       <button type="button" class="btn btn-info d-sm-inline d-none" data-toggle="modal" data-target="#new-modal">
         <i class="fas fa-plus-square"></i> 投稿する
       </button>
-      <button type="button" class="btn btn-outline-secondary d-sm-inline d-none">
+      <button type="button" class="btn btn-outline-secondary d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">
         <i class="fas fa-search"></i> 検索する
       </button>
       <%# 要素を右寄せで配置 %>
@@ -53,3 +53,4 @@
 </nav>
 <%# モーダルの部分テンプレート %>
 <%= render 'shared/modal', action: 'new', title: '新規登録' %>
+<%= render 'shared/modal', action: 'search', title: '検索' %>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -51,6 +51,3 @@
     <% end %>
   </div>
 </nav>
-<%# モーダルの部分テンプレート %>
-<%= render 'shared/modal', action: 'new', title: '新規登録' %>
-<%= render 'shared/modal', action: 'search', title: '検索' %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -2,7 +2,7 @@
   <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title"><%= title %></h5>
+        <h4 class="modal-title font-weight-bold"><%= title %></h4>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -6,30 +6,38 @@
   </div>
   <hr>
   <div class="form-group mt-3">
-    <i class="fas fa-tag"></i>
+    <i class="fas fa-tag tag-color"></i>
     <%= form.label :tags_id_in, "タグ", class: "font-weight-bold" %>
-    <div class="row">
+    <ul class="row px-3">
       <%= form.collection_check_boxes :tags_id_in, Tag.all, :id, :name, include_hidden: false do |form| %>
-        <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
-          <%= form.check_box %>
-          <%= form.text %>
-        </label>
+        <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
+          <label class="border rounded-pill w-100">
+            <%= form.check_box class: "d-none" %>
+            <span class="d-flex justify-content-center rounded-pill">
+              <%= form.text %>
+            </span>
+          </label>
+        </li>
       <% end %>
-    </div>
+    </ul>
   </div>
   <hr>
   <div class="form-group mt-3">
-    <i class="fas fa-folder"></i>
+    <i class="fas fa-folder category-color"></i>
     <%= form.label :categories_id_in, "カテゴリー", class: "font-weight-bold" %>
-    <div class="row">
+    <ul class="row px-3">
       <%= form.collection_check_boxes :categories_id_in, Category.all, :id, :name, include_hidden: false do |form| %>
-        <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
-          <%= form.check_box %>
-          <%= form.text %>
-        </label>
+        <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
+          <label class="rounded-pill w-100">
+            <%= form.check_box class: "d-none" %>
+            <span class="d-flex justify-content-center border rounded-pill">
+              <%= form.text %>
+            </span>
+          </label>
+        </li>
       <% end %>
-    </div>
+    </ul>
   </div>
-  <hr>
-  <%= form.submit "検索する", class: 'btn btn-info btn-block' %>
+  <hr class="py-2 m-0">
+  <%= form.submit "検索する", class: 'btn btn-info btn-block my-3' %>
 <% end %>

--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -40,4 +40,5 @@
   </div>
   <hr class="py-2 m-0">
   <%= form.submit "検索する", class: 'btn btn-info btn-block my-3' %>
+  <button type="button" class="btn btn-secondary btn-block my-3" id="reset-button">リセット</button>
 <% end %>

--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -1,0 +1,35 @@
+<%= search_form_for @q do |form| %>
+  <div class="form-group pb-3">
+    <i class="fas fa-search"></i>
+    <%= form.label :user_name_or_content_cont, "キーワード", class: "font-weight-bold" %>
+    <%= form.search_field :user_name_or_content_cont, class: 'form-control', placeholder: "キーワードを入力" %>
+  </div>
+  <hr>
+  <div class="form-group mt-3">
+    <i class="fas fa-tag"></i>
+    <%= form.label :tags_id_in, "タグ", class: "font-weight-bold" %>
+    <div class="row">
+      <%= form.collection_check_boxes :tags_id_in, Tag.all, :id, :name, include_hidden: false do |form| %>
+        <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
+          <%= form.check_box %>
+          <%= form.text %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+  <hr>
+  <div class="form-group mt-3">
+    <i class="fas fa-folder"></i>
+    <%= form.label :categories_id_in, "カテゴリー", class: "font-weight-bold" %>
+    <div class="row">
+      <%= form.collection_check_boxes :categories_id_in, Category.all, :id, :name, include_hidden: false do |form| %>
+        <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
+          <%= form.check_box %>
+          <%= form.text %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+  <hr>
+  <%= form.submit "検索する", class: 'btn btn-info btn-block' %>
+<% end %>


### PR DESCRIPTION
close #16 
  
## 実装内容
- `ransack`をインストール
- ナビゲーションバーに検索モーダル呼び出しのボタンを設定
- モーダルに検索フォームを実装
  - `search_form_for`ヘルパーメソッドを使用
  - 検索フォームには`キーワード`、`タグ`、`カテゴリー`での検索項目を設定
  - 部分一致可能(カラム名_cont を使用)
  - キーワードでは`ユーザー名`も検索できるように実装
- リセット機能を実装
  - 押下すると全ての条件をリセットするように実装
- ransack を用いた検索機能を利用するための処理は、検索モーダルを全ページで呼び出せるようにしているため`application_controller.rb`に記載して処理を共通化
- 検索後はタイムラインへレンダリング
  
## 動作確認
- [x] ローカル環境で動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行