### PR TITLE
ユーザーページの投稿一覧の表示を修正

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -10,21 +10,32 @@
   font-size: 18px;
 }
 
-#list-tab a.active {
-  background-color: #f8f9fa;
-  border: transparent;
+#list-tab {
+  a {
+    border: 0;
+    background-color: transparent;
+    opacity: 0.5;
+    &:hover {
+      background-color: #dedcda;
+      opacity: 1.0;
+    }
+  }
+  a.active {
+  border-bottom: 2px solid;
+  background-color: transparent;
+  opacity: 1.0;
+  }
 }
 
 #custom-pagination {
   justify-content: center;
   .page-link {
-    background-color: #f8f9fa;
-    border: transparent;
-    color: #212529;
+    background-color: transparent;
+    border: 0;
+    color: unset;
     &:hover {
       border-radius: 50%;
-      background-color: #EEEDEC;
-      color: #212529;
+      background-color: #dedcda;
     }
   }
   .active .page-link {
@@ -33,7 +44,7 @@
     color: #f8f9fa;
   }
   .disabled .page-link {
-    background-color: #f8f9fa;
+    background-color: transparent;
   }
 }
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   PER_PAGE = 9
   def show
     @user = User.find(params[:id])
-    @posts = Post.includes(:photos).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @posts = @user.posts.includes(:photos).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @page = params[:page]
   end
 end

--- a/app/views/users/_posts_paginate.html.erb
+++ b/app/views/users/_posts_paginate.html.erb
@@ -1,7 +1,7 @@
 <div class="tab-pane fade show active jscroll" id="list-posts" role="tabpanel" area-labelledby="list-posts-list">
   <div class="d-flex flex-wrap">
     <% posts.each do |post| %>
-      <div class="col-4 p-1 bg-light">
+      <div class="col-4 p-1">
       <%= link_to post_path(post) do %>
         <%= image_tag post.photos.first.image.url, class: "img-fluid fadein-image", width: "1080px", height: "1080px" %>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,18 +24,18 @@
     <% end %>
   </div>
   <div class="col-12 col-md-6 d-flex flex-column h-100">
-    <div class="list-group list-group-horizontal w-100 p-0" id="list-tab" role="tablist">
-      <a class="list-group-item flex-fill list-group-item-dark list-group-item-action active text-reset border-bottom-0 rounded-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts">
+    <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">
+      <a class="list-group-item flex-fill list-group-item-action active text-reset rounded-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts">
         <small class="d-flex justify-content-around">投稿</small>
       </a>
-      <a class="list-group-item flex-fill list-group-item-dark list-group-item-action text-reset border-bottom-0 rounded-0" id="list-liked-list" data-toggle="list" href="#list-liked" role="tab" aria-controls="liked">
+      <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0" id="list-liked-list" data-toggle="list" href="#list-liked" role="tab" aria-controls="liked">
         <small class="d-flex justify-content-around">いいね一覧</small>
       </a>
-      <a class="list-group-item flex-fill list-group-item-dark list-group-item-action text-reset border-bottom-0 rounded-0" id="list-marked-list" data-toggle="list" href="#list-marked" role="tab" aria-controls="marked">
+      <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0" id="list-marked-list" data-toggle="list" href="#list-marked" role="tab" aria-controls="marked">
         <small class="d-flex justify-content-around">マーク一覧</small>
       </a>
     </div>
-    <div class="tab-content pt-3 bg-light" id="nav-tabContent">
+    <div class="tab-content pt-3" id="nav-tabContent">
       <%= render "posts_paginate", posts: @posts %>
       <div class="tab-pane fade" id="list-liked" role="tabpanel" area-labelledby="list-liked-list">
         <div class="col-md-4 p-1">


### PR DESCRIPTION
close #97
  
## 実装内容
- ユーザーページの投稿一覧をユーザーの投稿のみの表示に修正
  - 全ての投稿が表示されるようになってしまっていたため
- 投稿の表示スタイルを修正
  - タブ・背景の透明化
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`の実行
- [x] `bundle exec rails_best_practices .`の実行