### PR TITLE
新規投稿・編集フォームのタグ・カテゴリー選択のチェックボックスのスタイルを修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,7 +78,17 @@ a:hover {
 }
 
 .form-check label {
+  position: relative;
   cursor: pointer;
+  .checkbox-visibility {
+    visibility: hidden;
+  }
+  .checkbox-position {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+  }
 }
 
 input:checked + span {

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -43,6 +43,8 @@ class PostForm
 
   def post_create
     post = Post.new(content: content, user_id: current_user_id, tag_ids: tag_ids, category_ids: category_ids)
+    return if image.blank?
+
     image.each do |img|
       post.photos.build(image: img).save!
     end

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -4,6 +4,7 @@ $(document).on('turbolinks:load', function () {
     let edit_file_field = document.querySelector('input[data-action=edit]');
     let newDataBox = new DataTransfer();
     let new_file_field = document.querySelector('input[data-action=new]');
+    $('#new-button').prop('disabled', true);
     // 画像選択時にプレビューを表示
     $('.post-preview-image').on("change", function(){
       let dataBox, fileField

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -16,6 +16,12 @@ $(document).on('turbolinks:load', function () {
         dataBox = newDataBox
         fileField = new_file_field
       }
+        // 選択をキャンセルした場合の処理
+      if ($(this).val() === "") {
+        $('.preview-item').remove();
+        fileField.files = dataBox.files
+        dataBox.clearData();
+      }
       const files = $('input[type="file"]').prop('files')[0];
       $.each(this.files, function(i, file){
         const fileReader = new FileReader();

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -24,8 +24,11 @@ $(document).on('turbolinks:load', function() {
                       </div>`;
           $('#edit-drop').before($(html));
           const previewItemLength = $('#edit-drop').prevAll('.preview-item').length;
-          if ( previewItemLength >= 6 ){
-            $('#edit-drop').hide();
+          if ( previewItemLength >= 1 && previewItemLength <= 6 ) {
+            $('#edit-button').prop('disabled', false);
+            if ( previewItemLength === 6 ) {
+              $('#edit-drop').hide();
+            }
           }
         });
       }

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -14,26 +14,42 @@
   </div>
   <small>* 最大6枚まで投稿できます *</small>
   <hr>
-  <div class="form-group row mt-3 tag-group">
-    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
-      <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
-        <%= form.check_box class: "tags-check-box"%>
-        <%= form.text %>
-      </label>
-    <% end %>
+  <div class="form-group mt-3 tag-group">
+    <i class="fas fa-tag tag-color"></i>
+    <%= form.label :tag_ids, "タグ", class: "font-weight-bold" %>
+    <ul class="row px-3">
+      <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
+        <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
+          <label class="border rounded-pill w-100">
+            <%= form.check_box class: "tags-check-box checkbox-visibility" %>
+            <span class="d-flex justify-content-center rounded-pill w-100 checkbox-position">
+              <%= form.text %>
+            </span>
+          </label>
+        </li>
+      <% end %>
+    </ul>
   </div>
   <small>* 最大2つまで選択可能です *</small>
   <hr>
-  <div class="form-group row mt-3 category-group">
-    <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
-      <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap">
-        <%= form.check_box class: "categories-check-box"%>
-        <%= form.text %>
-      </label>
-    <% end %>
+  <div class="form-group mt-3 category-group">
+    <i class="fas fa-folder category-color"></i>
+    <%= form.label :category_ids, "カテゴリー", class: "font-weight-bold" %>
+    <ul class="row px-3">
+      <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
+        <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
+          <label class="border rounded-pill w-100">
+            <%= form.check_box class: "categories-check-box checkbox-visibility" %>
+            <span class="d-flex justify-content-center rounded-pill w-100 checkbox-position">
+              <%= form.text %>
+            </span>
+          </label>
+        </li>
+      <% end %>
+    </ul>
   </div>
   <small>* 最大2つまで選択可能です *</small>
-  <hr>
+  <hr class="py-2 m-0">
   <div class="form-group mt-3">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'edit-button' %>
   </div>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -14,26 +14,42 @@
   </div>
   <small>* 最大6枚まで投稿できます *</small>
   <hr>
-  <div class="form-group row mt-3 tag-group">
-    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
-      <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap m-0">
-        <%= form.check_box %>
-        <%= form.text %>
-      </label>
-    <% end %>
+  <div class="form-group mt-3 tag-group">
+    <i class="fas fa-tag tag-color"></i>
+    <%= form.label :tag_ids, "タグ", class: "font-weight-bold" %>
+    <ul class="row px-3">
+      <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
+        <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
+          <label class="border rounded-pill w-100">
+            <%= form.check_box class: "checkbox-visibility" %>
+            <span class="d-flex justify-content-center rounded-pill w-100 checkbox-position">
+              <%= form.text %>
+            </span>
+          </label>
+        </li>
+      <% end %>
+    </ul>
   </div>
   <small>* 最大2つまで選択可能です *</small>
   <hr>
-  <div class="form-group row mt-3 category-group">
-    <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
-      <label class="form-check col-6 col-md-4 col-lg-2 flex-wrap">
-        <%= form.check_box %>
-        <%= form.text %>
-      </label>
-    <% end %>
+  <div class="form-group mt-3 category-group">
+    <i class="fas fa-folder category-color"></i>
+    <%= form.label :category_ids, "カテゴリー", class: "font-weight-bold" %>
+    <ul class="row px-3">
+      <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
+        <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
+          <label class="border rounded-pill w-100">
+            <%= form.check_box class: "checkbox-visibility" %>
+            <span class="d-flex justify-content-center rounded-pill w-100 checkbox-position">
+              <%= form.text %>
+            </span>
+          </label>
+        </li>
+      <% end %>
+    </ul>
   </div>
   <small>* 最大2つまで選択可能です *</small>
-  <hr>
+  <hr class="py-2 m-0">
   <div class="form-group mt-4">
     <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>
   </div>


### PR DESCRIPTION
close #98
  
## 実装内容
- 新規投稿・編集フォームのタグ・カテゴリー選択のチェックボックスのスタイルを修正
  - チェックボックスのデザインは`ボタン風`に設定
  - チェックが入ると色が変わるように設定
- 新規投稿時に画像を選択しないと送信ボタンを押下できないように処理を修正
- 編集モーダルを開閉時に送信ボタンの表示・非表示を切り替えるように処理を修正
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行