### PR TITLE
N ± 1 問題を解決

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,10 +36,13 @@ Rails/NotNullColumn:
 # メソッドの ABC サイズが構成された最大値を 25 に変更
 Metrics/AbcSize:
   Max: 25
+
 # ブロック長さが最大値を超えているかどうかをチェックから spec ファイルを解除
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+    - "config/environments/*.rb"
+
 # メソッドの最大行数を 20 に変更
 Metrics/MethodLength:
   Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,7 +37,7 @@ Rails/NotNullColumn:
 Metrics/AbcSize:
   Max: 25
 
-# ブロック長さが最大値を超えているかどうかをチェックから spec ファイルを解除
+# ブロック長さが最大値を超えているかどうかのチェックからファイル除外
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'bullet'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.5)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     carrierwave (2.2.2)
       activemodel (>= 5.0.0)
@@ -302,6 +305,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
+    uniform_notifier (1.14.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -326,6 +330,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bullet
   byebug
   carrierwave (~> 2.0)
   carrierwave-i18n

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,6 @@ class ApplicationController < ActionController::Base
 
   def set_search
     @q = Post.ransack(params[:q])
-    @posts = @q.result.includes(:photos).order(created_at: :desc)
+    @posts = @q.result.includes(:user, :photos, :tags, :categories).order(created_at: :desc)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,12 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end


### PR DESCRIPTION
close #103
  
## 実装内容
- gembulletをインストール
  - Rubocop の `Metrics/BlockLength` の検査から config/environments/*.rb ファイルを除外
  - config/environments/development.rb に bullet の設定を記述
- タイムラインページの N + 1 問題を解決
  - `incrudes`を使用して関連するモデルをまとめて取得
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `bullet`の警告が出ないことを確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails _best_practices .`を実行