### PR TITLE
Mark モデル・テーブルを作成

### DIFF
--- a/app/models/mark.rb
+++ b/app/models/mark.rb
@@ -1,0 +1,8 @@
+class Mark < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+  validates :user_id, uniqueness: {
+    scope: :post_id,
+    message: 'は同じ投稿に2回以上マークはできません'
+  }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,6 +8,8 @@ class Post < ApplicationRecord
   has_many :categories, through: :post_categories
   has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
+  has_many :marks, dependent: :destroy
+  has_many :marked_users, through: :marks, source: :user
 
   # user モデルの name を委譲する
   delegate :name, :avater, :id, to: :user, prefix: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
+  has_many :marks, dependent: :destroy
+  has_many :marked_posts, through: :marks, source: :post
 
   validates :name, presence: true, length: { maximum: 30 }
   validates :age, presence: true

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       post: 投稿
       comment: コメント
       like: いいね
+      mark: マーク
     attributes:
       post:
         content: 投稿内容
@@ -14,6 +15,9 @@ ja:
         content: コメント内容
         user: ユーザー
       like:
+        user: ユーザー
+        post: 投稿
+      mark:
         user: ユーザー
         post: 投稿
   views:

--- a/db/migrate/20211128045032_create_marks.rb
+++ b/db/migrate/20211128045032_create_marks.rb
@@ -1,0 +1,11 @@
+class CreateMarks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :marks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :marks, [:user_id, :post_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_19_142039) do
+ActiveRecord::Schema.define(version: 2021_11_28_045032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,16 @@ ActiveRecord::Schema.define(version: 2021_11_19_142039) do
     t.index ["post_id"], name: "index_likes_on_post_id"
     t.index ["user_id", "post_id"], name: "index_likes_on_user_id_and_post_id", unique: true
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "marks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_marks_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_marks_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_marks_on_user_id"
   end
 
   create_table "photos", force: :cascade do |t|
@@ -108,6 +118,8 @@ ActiveRecord::Schema.define(version: 2021_11_19_142039) do
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "marks", "posts"
+  add_foreign_key "marks", "users"
   add_foreign_key "photos", "posts"
   add_foreign_key "post_categories", "categories"
   add_foreign_key "post_categories", "posts"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,3 +75,9 @@ post1.likes.create!(user_id: 1)
 post2.likes.create!(user_id: 1)
 post3.likes.create!(user_id: 1)
 puts 'いいねの初期データインポートに成功しました。'
+
+ActiveRecord::Base.connection.execute('TRUNCATE TABLE marks RESTART IDENTITY CASCADE')
+post1.marks.create!(user_id: 1)
+post2.marks.create!(user_id: 1)
+post3.marks.create!(user_id: 1)
+puts 'マークの初期データインポートに成功しました。'

--- a/spec/factories/marks.rb
+++ b/spec/factories/marks.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :mark do
+    user { nil }
+    post { nil }
+  end
+end

--- a/spec/models/mark_spec.rb
+++ b/spec/models/mark_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Mark, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #14 
  
## 実装内容
- Mark モデル・テーブルを作成
  - `user_id`と`post_id`に一意制制約を設定
  - 同じ投稿にマークできないようにバリデーションを設定
- `Mark モデル`と`User モデル``Post モデル`を関連付け
- `Mark モデル`に関連する日本語訳を設定
- `マークの`初期データを作成
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行