### PR TITLE
マーク機能を実装

### DIFF
--- a/app/assets/stylesheets/marks.scss
+++ b/app/assets/stylesheets/marks.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the marks controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/marks.scss
+++ b/app/assets/stylesheets/marks.scss
@@ -1,3 +1,11 @@
 // Place all the styles related to the marks controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.mark-color {
+  color: #947b60;
+}
+
+.unmark-color {
+  color: #6c757d;
+}

--- a/app/controllers/marks_controller.rb
+++ b/app/controllers/marks_controller.rb
@@ -1,0 +1,2 @@
+class MarksController < ApplicationController
+end

--- a/app/controllers/marks_controller.rb
+++ b/app/controllers/marks_controller.rb
@@ -1,2 +1,19 @@
 class MarksController < ApplicationController
+  before_action :set_post
+
+  def create
+    current_user.marks.create!(post_id: params[:post_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.marks.find_by(post_id: params[:post_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
 end

--- a/app/controllers/marks_controller.rb
+++ b/app/controllers/marks_controller.rb
@@ -3,12 +3,10 @@ class MarksController < ApplicationController
 
   def create
     current_user.marks.create!(post_id: params[:post_id])
-    redirect_back(fallback_location: root_path)
   end
 
   def destroy
     current_user.marks.find_by(post_id: params[:post_id]).destroy!
-    redirect_back(fallback_location: root_path)
   end
 
   private

--- a/app/controllers/marks_controller.rb
+++ b/app/controllers/marks_controller.rb
@@ -1,12 +1,12 @@
 class MarksController < ApplicationController
-  before_action :set_post
-
   def create
     current_user.marks.create!(post_id: params[:post_id])
+    set_post
   end
 
   def destroy
     current_user.marks.find_by(post_id: params[:post_id]).destroy!
+    set_post
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   PER_PAGE = 20
 
   def index
-    @posts = @q.result.includes(:user, :photos, :tags, :categories, :likes).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @posts = @q.result.includes(:user, :photos, :tags, :categories, :likes, :marks).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @page = params[:page]
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,9 +2,9 @@ class UsersController < ApplicationController
   PER_PAGE = 9
   def show
     @user = User.find(params[:id])
-    @posts = @user.posts.includes(:photos).order(created_at: :desc).page(params[:post_page]).per(PER_PAGE)
-    @likes = @user.liked_posts.includes(:photos).order(created_at: :desc).page(params[:like_page]).per(PER_PAGE)
-    @marks = @user.marked_posts.includes(:photos).order(created_at: :desc).page(params[:mark_page]).per(PER_PAGE)
     @page = params[:page]
+    @posts = @user.post_with_photos.page(params[:post_page]).per(PER_PAGE)
+    @likes = @user.like_with_photos.page(params[:like_page]).per(PER_PAGE)
+    @marks = @user.mark_with_photos.page(params[:mark_page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     @posts = @user.posts.includes(:photos).order(created_at: :desc).page(params[:post_page]).per(PER_PAGE)
     @likes = @user.liked_posts.includes(:photos).order(created_at: :desc).page(params[:like_page]).per(PER_PAGE)
+    @marks = @user.marked_posts.includes(:photos).order(created_at: :desc).page(params[:mark_page]).per(PER_PAGE)
     @page = params[:page]
   end
 end

--- a/app/helpers/marks_helper.rb
+++ b/app/helpers/marks_helper.rb
@@ -1,0 +1,2 @@
+module MarksHelper
+end

--- a/app/javascript/packs/jscroll.js
+++ b/app/javascript/packs/jscroll.js
@@ -2,18 +2,31 @@ $(document).on('turbolinks:load', function(){
   $(function(){
     const windowSize = $(window).width();
     if (windowSize < 576) {
-      const jscrollOption = {
-        loadingHtml: '<div class="d-flex justify-content-center"><div class="spinner-border text-secondary" role="status"><span class="sr-only">Loading...</span></div></div>',
-        autoTrigger: true,
-        padding: 100,
-        nextSelector: 'a[rel=next]',
-        contentSelector: '.jscroll',
-        pagingSelector: '.pagination',
-        callback: function(){
-          $('.pagination').hide();
-        }
-      };
-      $('.jscroll').jscroll(jscrollOption);
+      function jscrollOption(tabId){
+        const Option = {
+          loadingHtml: '<div class="d-flex justify-content-center"><div class="spinner-border text-secondary" role="status"><span class="sr-only">Loading...</span></div></div>',
+          autoTrigger: true,
+          padding: 100,
+          nextSelector: 'a[rel=next]',
+          contentSelector: `#${tabId}`,
+          pagingSelector: '.pagination',
+          callback: function(){
+            $(this).children().addClass('show');
+            $('.pagination').hide();
+          }
+        };
+        $(`#${tabId}`).jscroll(Option);
+      }
+
+      // ユーザーページアクセス時にアクティブ状態のタブに jscroll を設定
+      const activeId = $('.tab-pane.active')[0].id;
+      jscrollOption(activeId);
+
+      // タブ切り替え表示の際にアクティブ状態のタブに jscroll を設定
+      $('a[data-toggle="list"]').on('shown.bs.tab', function (e) {
+        const tabId = e.target.dataset.tab;
+        jscrollOption(tabId);
+      });
     }
   });
 });

--- a/app/models/mark.rb
+++ b/app/models/mark.rb
@@ -1,6 +1,6 @@
 class Mark < ApplicationRecord
   belongs_to :user
-  belongs_to :post
+  belongs_to :post, counter_cache: :marks_count
   validates :user_id, uniqueness: {
     scope: :post_id,
     message: 'は同じ投稿に2回以上マークはできません'

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,4 +17,8 @@ class Post < ApplicationRecord
   def liked_by?(current_user)
     likes.any? { |like| like.user_id == current_user.id }
   end
+
+  def marked_by?(current_user)
+    marks.any? { |mark| mark.user_id == current_user.id }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,4 +87,16 @@ class User < ApplicationRecord
     five_person_household: 5,
     others_household: 6
   }
+
+  def post_with_photos
+    posts.includes(:photos).order(created_at: :desc)
+  end
+
+  def like_with_photos
+    liked_posts.includes(:photos).order(created_at: :desc)
+  end
+
+  def mark_with_photos
+    marked_posts.includes(:photos).order(created_at: :desc)
+  end
 end

--- a/app/views/marks/create.js.erb
+++ b/app/views/marks/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('post-<%= @post.id %>-mark').innerHTML = '<%= j render("posts/mark", post: @post) %>';

--- a/app/views/marks/create.js.erb
+++ b/app/views/marks/create.js.erb
@@ -1,1 +1,2 @@
 document.getElementById('post-<%= @post.id %>-mark').innerHTML = '<%= j render("posts/mark", post: @post) %>';
+document.getElementById('post-<%= @post.id %>-marks-count').innerHTML = '<%= j render("posts/marks_count", post: @post) %>'

--- a/app/views/marks/destroy.js.erb
+++ b/app/views/marks/destroy.js.erb
@@ -1,1 +1,2 @@
 document.getElementById('post-<%= @post.id %>-mark').innerHTML = '<%= j render("posts/unmark", post: @post) %>';
+document.getElementById('post-<%= @post.id %>-marks-count').innerHTML = '<%= j render("posts/marks_count", post: @post) %>'

--- a/app/views/marks/destroy.js.erb
+++ b/app/views/marks/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('post-<%= @post.id %>-mark').innerHTML = '<%= j render("posts/unmark", post: @post) %>';

--- a/app/views/posts/_likes_count.html.erb
+++ b/app/views/posts/_likes_count.html.erb
@@ -1,5 +1,5 @@
 <% if post.likes_count >= 1 %>
-  <div class="d-flex align-items-end">
+  <div class="d-flex align-items-end ml-n4">
     <%= post.likes_count %>
   </div>
 <% end %>

--- a/app/views/posts/_mark.html.erb
+++ b/app/views/posts/_mark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to post_marks_path(post), method: :delete, class: "text-reset p-1" do %>
+  <i class="fas fa-bookmark fa-lg mark-color"></i>
+<% end %>

--- a/app/views/posts/_mark.html.erb
+++ b/app/views/posts/_mark.html.erb
@@ -1,3 +1,3 @@
-<%= link_to post_marks_path(post), method: :delete, class: "text-reset p-1" do %>
+<%= link_to post_marks_path(post), method: :delete, class: "text-reset p-1", remote: true do %>
   <i class="fas fa-bookmark fa-lg mark-color"></i>
 <% end %>

--- a/app/views/posts/_marks_count.html.erb
+++ b/app/views/posts/_marks_count.html.erb
@@ -1,0 +1,5 @@
+<% if post.marks_count >= 1 %>
+  <div class="d-flex align-items-end ml-n4">
+    <%= post.marks_count %>
+  </div>
+<% end %>

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -26,15 +26,18 @@
                   <%= render "dislike", post: post %>
                 <% end %>
               </div>
-              <div class="d-flex" id="post-<%= post.id %>-likes-count">
+              <div id="post-<%= post.id %>-likes-count">
                 <%= render "likes_count", post: post %>
               </div>
-              <div id="post-<%= post.id %>-mark">
+              <div class="mr-4" id="post-<%= post.id %>-mark">
                 <% if post.marked_by?(current_user) %>
                   <%= render "mark", post: post %>
                 <% else %>
                   <%= render "unmark", post: post %>
                 <% end %>
+              </div>
+              <div id="post-<%= post.id %>-marks-count">
+                <%= render "marks_count", post: post %>
               </div>
             </div>
             <small class="d-flex flex-wrap border-top px-3">

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -29,6 +29,13 @@
               <div class="d-flex" id="post-<%= post.id %>-likes-count">
                 <%= render "likes_count", post: post %>
               </div>
+              <div id="post-<%= post.id %>-mark">
+                <% if post.marked_by?(current_user) %>
+                  <%= render "mark", post: post %>
+                <% else %>
+                  <%= render "unmark", post: post %>
+                <% end %>
+              </div>
             </div>
             <small class="d-flex flex-wrap border-top px-3">
               <div class="pt-2 d-none d-lg-block">

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -19,7 +19,7 @@
               <% end %>
             </div>
             <div class="d-flex border-top px-3 py-2">
-              <div id="post-<%= post.id %>-like">
+              <div class="mr-4" id="post-<%= post.id %>-like">
                 <% if post.liked_by?(current_user) %>
                   <%= render "like", post: post %>
                 <% else %>

--- a/app/views/posts/_unmark.html.erb
+++ b/app/views/posts/_unmark.html.erb
@@ -1,0 +1,3 @@
+<%= link_to post_marks_path(post), method: :post, class: "text-reset p-1" do %>
+  <i class="far fa-bookmark fa-lg unmark-color"></i>
+<% end %>

--- a/app/views/posts/_unmark.html.erb
+++ b/app/views/posts/_unmark.html.erb
@@ -1,3 +1,3 @@
-<%= link_to post_marks_path(post), method: :post, class: "text-reset p-1" do %>
+<%= link_to post_marks_path(post), method: :post, class: "text-reset p-1", remote: true do %>
   <i class="far fa-bookmark fa-lg unmark-color"></i>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -87,7 +87,7 @@
           </div>
         </div>
         <div class="d-flex border-top px-3 pt-3">
-          <div id="post-<%= @post.id %>-like">
+          <div class="mr-4" id="post-<%= @post.id %>-like">
             <% if @post.liked_by?(current_user) %>
               <%= render "like", post: @post %>
             <% else %>
@@ -96,6 +96,13 @@
           </div>
           <div id="post-<%= @post.id %>-likes-count">
             <%= render "likes_count", post: @post %>
+          </div>
+          <div id="post-<%= @post.id %>-mark">
+            <% if @post.marked_by?(current_user) %>
+              <%= render "mark", post: @post %>
+            <% else %>
+              <%= render "unmark", post: @post %>
+            <% end %>
           </div>
         </div>
         <div class="card-form p-3">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -97,12 +97,15 @@
           <div id="post-<%= @post.id %>-likes-count">
             <%= render "likes_count", post: @post %>
           </div>
-          <div id="post-<%= @post.id %>-mark">
+          <div class="mr-4" id="post-<%= @post.id %>-mark">
             <% if @post.marked_by?(current_user) %>
               <%= render "mark", post: @post %>
             <% else %>
               <%= render "unmark", post: @post %>
             <% end %>
+          </div>
+          <div id="post-<%= @post.id %>-marks-count">
+            <%= render "marks_count", post: @post %>
           </div>
         </div>
         <div class="card-form p-3">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -59,8 +59,11 @@
         </div>
       </div>
       <div class="tab-pane fade" id="list-marked" role="tabpanel" area-labelledby="list-marked-list">
-        <div class="col-md-4 p-1">
-          <p>マーク済み</p>
+        <div class="d-flex flex-wrap" id="posts-marked">
+          <%= render partial: "posts_paginate", collection: @marks, as: "post" %>
+        </div>
+        <div id="posts-marked-paginate">
+          <%= paginate @marks, param_name: "mark_page", remote: true, params: { data: "mark" } %>
         </div>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,24 +25,24 @@
   </div>
   <div class="col-12 col-md-6 d-flex flex-column h-100">
     <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">
-      <a class="list-group-item flex-fill list-group-item-action active text-reset rounded-0 px-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts">
+      <a class="list-group-item flex-fill list-group-item-action active text-reset rounded-0 px-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts" data-tab="list-posts">
         <small class="d-flex justify-content-center">
           <i class="far fa-folder-open align-self-center mr-1"></i>投稿
         </small>
       </a>
-      <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-liked-list" data-toggle="list" href="#list-liked" role="tab" aria-controls="liked">
+      <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-liked-list" data-toggle="list" href="#list-liked" role="tab" aria-controls="liked" data-tab="list-liked">
         <small class="d-flex justify-content-center">
           <i class="far fa-heart align-self-center mr-1"></i>いいね一覧
         </small>
       </a>
-      <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-marked-list" data-toggle="list" href="#list-marked" role="tab" aria-controls="marked">
+      <a class="list-group-item flex-fill list-group-item-action text-reset rounded-0 px-0" id="list-marked-list" data-toggle="list" href="#list-marked" role="tab" aria-controls="marked" data-tab="list-marked">
         <small class="d-flex justify-content-center">
           <i class="far fa-bookmark align-self-center mr-1"></i>マーク一覧
         </small>
       </a>
     </div>
     <div class="tab-content pt-3" id="nav-tabContent">
-      <div class="tab-pane fade show active jscroll" id="list-posts" role="tabpanel" area-labelledby="list-posts-list">
+      <div class="tab-pane fade show active" id="list-posts" role="tabpanel" area-labelledby="list-posts-list">
         <div class="d-flex flex-wrap" id="user-posts">
           <%= render partial: "posts_paginate", collection: @posts, as: "post" %>
         </div>

--- a/app/views/users/show.js.erb
+++ b/app/views/users/show.js.erb
@@ -3,10 +3,15 @@ if('<%= params[:data] %>' === 'user'){
   document.getElementById('user-posts').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @posts, as: "post") %>');
   document.getElementById('user-posts-paginate').textContent = '';
   document.getElementById('user-posts-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @posts, param_name: "post_page", remote: true, params: { data: "user" }) %>');
-} else {
+} else if('<%= params[:data] %>' === 'like'){ 
   document.getElementById('posts-liked').textContent = '';
   document.getElementById('posts-liked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @likes, as: "post") %>');
   document.getElementById('posts-liked-paginate').textContent = '';
   document.getElementById('posts-liked-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @likes, param_name: "like_page", remote: true, params: { data: "like" }) %>');
+} else {
+  document.getElementById('posts-marked').textContent = '';
+  document.getElementById('posts-marked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @marks, as: "post") %>');
+  document.getElementById('posts-marked-paginate').textContent = '';
+  document.getElementById('posts-marked-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @marks, param_name: "mark_page", remote: true, params: { data: "mark" }) %>');
 }
 history.replaceState( "", "" ,"?page=<%= @page %>");

--- a/app/views/users/show.js.erb
+++ b/app/views/users/show.js.erb
@@ -3,7 +3,7 @@ if('<%= params[:data] %>' === 'user'){
   document.getElementById('user-posts').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @posts, as: "post") %>');
   document.getElementById('user-posts-paginate').textContent = '';
   document.getElementById('user-posts-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @posts, param_name: "post_page", remote: true, params: { data: "user" }) %>');
-} else if('<%= params[:data] %>' === 'like'){ 
+} else if('<%= params[:data] %>' === 'like'){
   document.getElementById('posts-liked').textContent = '';
   document.getElementById('posts-liked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @likes, as: "post") %>');
   document.getElementById('posts-liked-paginate').textContent = '';

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   resources :posts, except: %i[new edit] do
     resources :comments, only: %i[create destroy]
     resource :likes, only: %i[create destroy]
+    resource :marks, only: %i[create destroy]
   end
 end

--- a/db/migrate/20211119142039_reset_all_post_likes_cache_counters.rb
+++ b/db/migrate/20211119142039_reset_all_post_likes_cache_counters.rb
@@ -1,4 +1,4 @@
-class ResetAllPostCacheCounters < ActiveRecord::Migration[6.1]
+class ResetAllPostLikesCacheCounters < ActiveRecord::Migration[6.1]
   def up
     Post.find_each { |post| Post.reset_counters(post.id, :likes_count) }
   end

--- a/db/migrate/20211202042449_reset_all_post_marks_cache_counters.rb
+++ b/db/migrate/20211202042449_reset_all_post_marks_cache_counters.rb
@@ -1,0 +1,7 @@
+class ResetAllPostMarksCacheCounters < ActiveRecord::Migration[6.1]
+  def up
+    Post.find_each { |post| Post.reset_counters(post.id, :marks_count) }
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_28_045032) do
+ActiveRecord::Schema.define(version: 2021_12_02_042449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/requests/marks_spec.rb
+++ b/spec/requests/marks_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Marks", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/marks_spec.rb
+++ b/spec/requests/marks_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Marks", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Marks', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
close #15 
  
## 実装内容
- marks コントローラを作成
  - posts コントローラにネストする形で設定
  - id は必要ない為`resources :marks`とする
  - アクションは`create`, `destroy`のみとする
- 投稿詳細ページ、タイムラインページにマーク機能を実装
  - `marked_by?`メソッドを Post モデルに定義してログインユーザーの id がと いいねしたユーザーの id が一致した場合とそうでない場合でマークの表示を条件分岐
  - `Ajax`で実装する
- マークボタンの横に`マーク数`を表示する
  - `Ajax`で表示する
- 画面幅が sm 以下の場合タブコンテンツを`jscroll`で表示
  - jscroll.js ファイルを共通化して、タブコンテンツごとに jscroll で読み込みできるように実装
- 別途作成したマーク数リセット用のマイグレーションファイルと区別しやすくするために、いいね数リセット用のマイグレーションファイル名を修正
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行