### PR TITLE
ゲストログイン機能を実装

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Users::ConfirmationsController < Devise::ConfirmationsController
-  # GET /resource/confirmation/new
-  # def new
-  #   super
-  # end
+module Users
+  class ConfirmationsController < Devise::ConfirmationsController
+    # GET /resource/confirmation/new
+    # def new
+    #   super
+    # end
 
-  # POST /resource/confirmation
-  # def create
-  #   super
-  # end
+    # POST /resource/confirmation
+    # def create
+    #   super
+    # end
 
-  # GET /resource/confirmation?confirmation_token=abcdef
-  # def show
-  #   super
-  # end
+    # GET /resource/confirmation?confirmation_token=abcdef
+    # def show
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # The path used after resending confirmation instructions.
-  # def after_resending_confirmation_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+    # The path used after resending confirmation instructions.
+    # def after_resending_confirmation_instructions_path_for(resource_name)
+    #   super(resource_name)
+    # end
 
-  # The path used after confirmation.
-  # def after_confirmation_path_for(resource_name, resource)
-  #   super(resource_name, resource)
-  # end
+    # The path used after confirmation.
+    # def after_confirmation_path_for(resource_name, resource)
+    #   super(resource_name, resource)
+    # end
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+module Users
+  class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    # You should configure your model like this:
+    # devise :omniauthable, omniauth_providers: [:twitter]
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+    # You should also create an action method in this controller like this:
+    # def twitter
+    # end
 
-  # More info at:
-  # https://github.com/heartcombo/devise#omniauth
+    # More info at:
+    # https://github.com/heartcombo/devise#omniauth
 
-  # GET|POST /resource/auth/twitter
-  # def passthru
-  #   super
-  # end
+    # GET|POST /resource/auth/twitter
+    # def passthru
+    #   super
+    # end
 
-  # GET|POST /users/auth/twitter/callback
-  # def failure
-  #   super
-  # end
+    # GET|POST /users/auth/twitter/callback
+    # def failure
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
+    # The path used when OmniAuth fails
+    # def after_omniauth_failure_path_for(scope)
+    #   super(scope)
+    # end
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  before_action :ensure_nomal_user, only: :create
+
   # GET /resource/password/new
   # def new
   #   super
@@ -22,6 +24,10 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # protected
+
+  def ensure_nomal_user
+    redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません' if params[:user][:email].downcase == 'guest@example.com'
+  end
 
   # def after_resetting_password_path_for(resource)
   #   super(resource)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,40 +1,42 @@
 # frozen_string_literal: true
 
-class Users::PasswordsController < Devise::PasswordsController
-  before_action :ensure_nomal_user, only: :create
+module Users
+  class PasswordsController < Devise::PasswordsController
+    before_action :ensure_nomal_user, only: :create
 
-  # GET /resource/password/new
-  # def new
-  #   super
-  # end
+    # GET /resource/password/new
+    # def new
+    #   super
+    # end
 
-  # POST /resource/password
-  # def create
-  #   super
-  # end
+    # POST /resource/password
+    # def create
+    #   super
+    # end
 
-  # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
+    # GET /resource/password/edit?reset_password_token=abcdef
+    # def edit
+    #   super
+    # end
 
-  # PUT /resource/password
-  # def update
-  #   super
-  # end
+    # PUT /resource/password
+    # def update
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  def ensure_nomal_user
-    redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません' if params[:user][:email].downcase == 'guest@example.com'
+    def ensure_nomal_user
+      redirect_to new_user_session_path, alert: 'ゲストユーザーのパスワード再設定はできません' if params[:user][:email].casecmp('guest@example.com').zero?
+    end
+
+    # def after_resetting_password_path_for(resource)
+    #   super(resource)
+    # end
+
+    # The path used after sending reset password instructions
+    # def after_sending_reset_password_instructions_path_for(resource_name)
+    #   super(resource_name)
+    # end
   end
-
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -25,9 +25,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # DELETE /resource
-  # def destroy
-  #   super
-  # end
+  def destroy
+    if resource.email == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーの削除はできません'
+      return
+    end
+    super
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  before_action :ensure_nomal_user, only: %i[update destroy]
 
   # GET /resource/sign_up
   # def new
@@ -25,13 +26,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # DELETE /resource
-  def destroy
-    if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーの削除はできません'
-      return
-    end
-    super
-  end
+  # def destroy
+  #   super
+  # end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign
@@ -43,6 +40,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # protected
+
+  def ensure_nomal_user
+    redirect_to user_path(current_user.id), alert: 'ゲストユーザーの削除・更新はできません' if resource.email == 'guest@example.com'
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,67 +1,69 @@
 # frozen_string_literal: true
 
-class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
-  before_action :ensure_nomal_user, only: %i[update destroy]
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    # before_action :configure_sign_up_params, only: [:create]
+    # before_action :configure_account_update_params, only: [:update]
+    before_action :ensure_nomal_user, only: %i[update destroy]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+    # GET /resource/sign_up
+    # def new
+    #   super
+    # end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+    # POST /resource
+    # def create
+    #   super
+    # end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+    # GET /resource/edit
+    # def edit
+    #   super
+    # end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+    # PUT /resource
+    # def update
+    #   super
+    # end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+    # DELETE /resource
+    # def destroy
+    #   super
+    # end
 
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+    # GET /resource/cancel
+    # Forces the session data which is usually expired after sign
+    # in to be expired now. This is useful if the user wants to
+    # cancel oauth signing in/up in the middle of the process,
+    # removing all OAuth session data.
+    # def cancel
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  def ensure_nomal_user
-    redirect_to user_path(current_user.id), alert: 'ゲストユーザーの削除・更新はできません' if resource.email == 'guest@example.com'
+    def ensure_nomal_user
+      redirect_to user_path(current_user.id), alert: 'ゲストユーザーの削除・更新はできません' if resource.email == 'guest@example.com'
+    end
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    # end
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_account_update_params
+    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    # end
+
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
   end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,6 +3,11 @@
 class Users::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
 
+  def guest_sign_in
+    sign_in User.guest
+    redirect_to root_path, notice: 'ゲストユーザーでログインしました'
+  end
+
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-class Users::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+module Users
+  class SessionsController < Devise::SessionsController
+    # before_action :configure_sign_in_params, only: [:create]
 
-  def guest_sign_in
-    sign_in User.guest
-    redirect_to root_path, notice: 'ゲストユーザーでログインしました'
+    def guest_sign_in
+      sign_in User.guest
+      redirect_to root_path, notice: 'ゲストユーザーでログインしました'
+    end
+
+    # GET /resource/sign_in
+    # def new
+    #   super
+    # end
+
+    # POST /resource/sign_in
+    # def create
+    #   super
+    # end
+
+    # DELETE /resource/sign_out
+    # def destroy
+    #   super
+    # end
+
+    # protected
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_in_params
+    #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+    # end
   end
-
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
 end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Users::UnlocksController < Devise::UnlocksController
-  # GET /resource/unlock/new
-  # def new
-  #   super
-  # end
+module Users
+  class UnlocksController < Devise::UnlocksController
+    # GET /resource/unlock/new
+    # def new
+    #   super
+    # end
 
-  # POST /resource/unlock
-  # def create
-  #   super
-  # end
+    # POST /resource/unlock
+    # def create
+    #   super
+    # end
 
-  # GET /resource/unlock?unlock_token=abcdef
-  # def show
-  #   super
-  # end
+    # GET /resource/unlock?unlock_token=abcdef
+    # def show
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # The path used after sending unlock password instructions
-  # def after_sending_unlock_instructions_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sending unlock password instructions
+    # def after_sending_unlock_instructions_path_for(resource)
+    #   super(resource)
+    # end
 
-  # The path used after unlocking the resource
-  # def after_unlock_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after unlocking the resource
+    # def after_unlock_path_for(resource)
+    #   super(resource)
+    # end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,4 +99,14 @@ class User < ApplicationRecord
   def mark_with_photos
     marked_posts.includes(:photos).order(created_at: :desc)
   end
+
+  def self.guest
+    find_or_create_by!(email: 'guest@example.com') do |user|
+      user.name = 'ゲストユーザー'
+      user.password = SecureRandom.urlsafe_base64
+      user.age = rand(1..7)
+      user.address = rand(1..47)
+      user.household = rand(1..6)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,9 +104,9 @@ class User < ApplicationRecord
     find_or_create_by!(email: 'guest@example.com') do |user|
       user.name = 'ゲストユーザー'
       user.password = SecureRandom.urlsafe_base64
-      user.age = rand(1..7)
-      user.address = rand(1..47)
-      user.household = rand(1..6)
+      user.age = 2
+      user.address = 13
+      user.household = 2
     end
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -2,6 +2,7 @@
 <% unless user_signed_in? %>
   <%= link_to "会員登録", new_user_registration_path, class: 'btn btn-info' %>
   <%= link_to "ログイン", new_user_session_path, class: 'btn btn-info' %>
+  <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: 'btn btn-success' %>
 <% end %>
   <h2>Feature</h2>
   <p>アプリについて</p>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -32,7 +32,7 @@
       </div>
     <% else %>
       <div class="navbar-nav ml-auto">
-        <%= link_to "#", class: "nav-item nav-link" do %>
+        <%= link_to users_guest_sign_in_path, method: :post, class: "nav-item nav-link" do %>
           <i class="fas fa-id-card-alt"></i> ゲストログイン
         <% end %>
         <%= link_to new_user_registration_path, class: "nav-item nav-link" do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: "users/registrations",
-    passwords: "users/passwords"
+    registrations: 'users/registrations',
+    passwords: 'users/passwords'
   }
   devise_scope :user do
-    post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+    post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
   end
   root 'homes#index'
   resources :users, only: %i[show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: "users/registrations"
+    registrations: "users/registrations",
+    passwords: "users/passwords"
   }
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
+  end
   root 'homes#index'
   resources :users, only: %i[show]
   resources :posts, except: %i[new edit] do


### PR DESCRIPTION
close #22 
  
## 実装内容
- トップページとナビバーにゲストログイン用のボタンを設置
- ゲストユーザーの作成は `Devise`の`sign_in`メソッドを使用
  - ゲストユーザーのデータは`User モデル`にメソッドで定義
- `rails g devise:controller user`を実行してコントローラを作成
  - ゲストユーザーのアカウント削除・編集を防ぐために`registrations コントローラ`の`update`, `destroy`アクションに `before_action`を設定してゲストユーザーの場合はユーザーページへリダイレクトするように処理
  - ゲストユーザーのパスワードの再設定を防ぐために`passwords コントローラ`の`create`アクションに `before_action`を設定してゲストユーザーの場合はパスワード再設定ページへリダイレクトするように処理
  
## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行