### PR TITLE
データ集計

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'carrierwave', '~> 2.0'
 gem 'carrierwave-i18n'
+gem "chartkick"
 gem 'devise'
 gem 'devise-bootstrap-views'
 gem 'devise-i18n'

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'carrierwave', '~> 2.0'
 gem 'carrierwave-i18n'
-gem "chartkick"
+gem 'chartkick'
 gem 'devise'
 gem 'devise-bootstrap-views'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     carrierwave-i18n (0.2.0)
+    chartkick (4.1.2)
     code_analyzer (0.5.2)
       sexp_processor
     coderay (1.1.3)
@@ -334,6 +335,7 @@ DEPENDENCIES
   byebug
   carrierwave (~> 2.0)
   carrierwave-i18n
+  chartkick
   devise
   devise-bootstrap-views
   devise-i18n

--- a/app/assets/stylesheets/graphs.scss
+++ b/app/assets/stylesheets/graphs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the graphs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/graphs.scss
+++ b/app/assets/stylesheets/graphs.scss
@@ -1,3 +1,16 @@
 // Place all the styles related to the graphs controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.rank-color-1 {
+  background-color: rgba(186, 168, 119, 0.3);
+  color: #212529;
+}
+.rank-color-2 {
+  background-color: rgba(168, 169, 168, 0.3);
+  color: #212529;
+}
+.rank-color-3 {
+  background-color: rgba(148, 123, 96, 0.3);
+  color: #212529;
+}

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -1,0 +1,2 @@
+class GraphsController < ApplicationController
+end

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -1,2 +1,8 @@
 class GraphsController < ApplicationController
+  def index
+    @tags_count_graph = Tag.joins(:post_tags).group(:name).order(count_all: :desc).count
+    @categories_count_graph = Category.joins(:post_categories).group(:name).order(count_all: :desc).count
+    @likes_count_graph = User.joins(:likes).group(:name).order(count_all: :desc).count
+    @likes_average_graph = User.joins(:posts).group(:name).order(average_likes_count: :desc).average(:likes_count)
+  end
 end

--- a/app/helpers/graphs_helper.rb
+++ b/app/helpers/graphs_helper.rb
@@ -1,0 +1,2 @@
+module GraphsHelper
+end

--- a/app/helpers/graphs_helper.rb
+++ b/app/helpers/graphs_helper.rb
@@ -1,9 +1,9 @@
 module GraphsHelper
   def result_label(table)
-    table == "likes_average" ? "平均" : "合計"
+    table == 'likes-average' ? '平均' : '合計'
   end
 
   def suffix_name(table)
-    table == "likes_count" || table == "likes_average" ? "いいね !" : "件"
+    ['likes-count', 'likes-average'].include?(table) ? 'いいね !' : '件'
   end
 end

--- a/app/helpers/graphs_helper.rb
+++ b/app/helpers/graphs_helper.rb
@@ -1,2 +1,9 @@
 module GraphsHelper
+  def result_label(table)
+    table == "likes_average" ? "平均" : "合計"
+  end
+
+  def suffix_name(table)
+    table == "likes_count" || table == "likes_average" ? "いいね !" : "件"
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,7 +22,7 @@ import "./jquery.validate.min"
 import "./validate_rules"
 import "./jscroll"
 import "./search"
-import "chartkick/chart.js"
+// import "chartkick/chart.js"
 import "chartkick/highcharts"
 
 Rails.start()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,6 +24,7 @@ import "./jscroll"
 import "./search"
 // import "chartkick/chart.js"
 import "chartkick/highcharts"
+import "./graph"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,6 +22,8 @@ import "./jquery.validate.min"
 import "./validate_rules"
 import "./jscroll"
 import "./search"
+import "chartkick/chart.js"
+
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,7 +23,7 @@ import "./validate_rules"
 import "./jscroll"
 import "./search"
 import "chartkick/chart.js"
-
+import "chartkick/highcharts"
 
 Rails.start()
 Turbolinks.start()

--- a/app/javascript/packs/graph.js
+++ b/app/javascript/packs/graph.js
@@ -2,17 +2,13 @@ $(document).on('turbolinks:load', function(){
   $(function(){
     function iconUpdate(collapseButton){
       if ($(collapseButton).hasClass('btn-outline-secondary')) {
-        $(collapseButton).addClass('btn-secondary');
-        $(collapseButton).removeClass('btn-outline-secondary');
+        $(collapseButton).toggleClass('btn-secondary btn-outline-secondary');
         const icon = $(collapseButton).children();
-        $(icon).removeClass('fa-plus');
-        $(icon).addClass('fa-minus');
+        $(icon).toggleClass('fa-plus fa-minus');
       } else {
-        $(collapseButton).addClass('btn-outline-secondary');
-        $(collapseButton).removeClass('btn-secondary');
+        $(collapseButton).toggleClass('btn-secondary btn-outline-secondary');
         const icon = $(collapseButton).children();
-        $(icon).removeClass('fa-minus');
-        $(icon).addClass('fa-plus');
+        $(icon).toggleClass('fa-plus fa-minus');
       }
     }
     const windowSize = $(window).width();

--- a/app/javascript/packs/graph.js
+++ b/app/javascript/packs/graph.js
@@ -1,0 +1,39 @@
+$(document).on('turbolinks:load', function(){
+  $(function(){
+    function iconUpdate(collapseButton){
+      if ($(collapseButton).hasClass('btn-outline-secondary')) {
+        $(collapseButton).addClass('btn-secondary');
+        $(collapseButton).removeClass('btn-outline-secondary');
+        const icon = $(collapseButton).children();
+        $(icon).removeClass('fa-plus');
+        $(icon).addClass('fa-minus');
+      } else {
+        $(collapseButton).addClass('btn-outline-secondary');
+        $(collapseButton).removeClass('btn-secondary');
+        const icon = $(collapseButton).children();
+        $(icon).removeClass('fa-minus');
+        $(icon).addClass('fa-plus');
+      }
+    }
+    const windowSize = $(window).width();
+    // 画面サイズが md 以上の場合
+    if (windowSize >= 768 ) {
+      $('.ranking-collapse').addClass('show');
+      $('.collapse-btn').each(function(index, value){
+        iconUpdate(value);
+      });
+    }
+    // コラプスを開いた際の処理
+    $('.ranking-collapse').on('show.bs.collapse', function(){
+      const id = this.id;
+      const collapseButton = $(`#collapse-${id}`);
+      iconUpdate(collapseButton);
+    })
+    // コラプスを閉じた際の処理
+    $('.ranking-collapse').on('hide.bs.collapse', function(){
+      const id = this.id;
+      const collapseButton = $(`#collapse-${id}`);
+      iconUpdate(collapseButton);
+    })
+  })
+});

--- a/app/javascript/packs/graph.js
+++ b/app/javascript/packs/graph.js
@@ -16,8 +16,8 @@ $(document).on('turbolinks:load', function(){
       }
     }
     const windowSize = $(window).width();
-    // 画面サイズが md 以上の場合
-    if (windowSize >= 768 ) {
+    // 画面サイズが lg 以上の場合
+    if (windowSize >= 992 ) {
       $('.ranking-collapse').addClass('show');
       $('.collapse-btn').each(function(index, value){
         iconUpdate(value);

--- a/app/javascript/packs/jscroll.js
+++ b/app/javascript/packs/jscroll.js
@@ -19,8 +19,7 @@ $(document).on('turbolinks:load', function(){
       }
 
       // ユーザーページアクセス時にアクティブ状態のタブに jscroll を設定
-      const activeId = $('.tab-pane.active')[0].id;
-      jscrollOption(activeId);
+        jscrollOption('list-posts');
 
       // タブ切り替え表示の際にアクティブ状態のタブに jscroll を設定
       $('a[data-toggle="list"]').on('shown.bs.tab', function (e) {

--- a/app/views/graphs/_collapse.html.erb
+++ b/app/views/graphs/_collapse.html.erb
@@ -1,7 +1,7 @@
 <div class="col-12 col-md-6 col-lg-12 px-2 mb-3">
   <div class="row">
     <div class="col-12 col-lg-4">
-      <%= pie_chart datas.to_a[0..2], title: title, label: result_label(table), suffix: suffix_name(table) %>
+      <%= pie_chart datas.uniq{|key, value| value}[0..2], title: title, label: result_label(table), suffix: suffix_name(table) %>
     </div>
     <div class="col-12 col-lg-8">
       <p class="d-flex justify-content-center m-0">
@@ -20,7 +20,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <%= render partial: "ranking_table", collection: datas.to_a[0..11], as: "data" %>
+                  <%= render "ranking_table", datas: datas %>
                 </tbody>
               </table>
             </div>

--- a/app/views/graphs/_collapse.html.erb
+++ b/app/views/graphs/_collapse.html.erb
@@ -1,24 +1,30 @@
-<div class="col-12 col-sm-6 col-md-3 p-0">
-  <%= pie_chart datas.to_a[0..2], title: title, label: result_label(table), suffix: suffix_name(table) %>
-  <p class="d-flex justify-content-center m-0">
-    <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
-  </p>
+<div class="col-12 col-md-6 col-lg-12 px-2 mb-3">
   <div class="row">
-    <div class="col">
-      <div class="collapse multi-collapse ranking-collapse" id="<%= table %>">
-        <div class="card">
-          <table class="table m-0">
-            <thead>
-              <tr>
-                <th scope="col" class="px-2 text-center text-nowrap">順位</th>
-                <th scope="col" class="px-2 text-center text-nowrap">名前</th>
-                <th scope="col" class="px-2 text-center text-nowrap"><%= result_label(table) %></th>
-              </tr>
-            </thead>
-            <tbody>
-              <%= render partial: "ranking_table", collection: datas.to_a[0..11], as: "data" %>
-            </tbody>
-          </table>
+    <div class="col-12 col-lg-4">
+      <%= pie_chart datas.to_a[0..2], title: title, label: result_label(table), suffix: suffix_name(table) %>
+    </div>
+    <div class="col-12 col-lg-8">
+      <p class="d-flex justify-content-center m-0">
+        <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
+      </p>
+      <div class="row">
+        <div class="col">
+          <div class="collapse multi-collapse ranking-collapse" id="<%= table %>">
+            <div class="card overflow-auto" style="height: 246px;">
+              <table class="table table-sm m-0">
+                <thead>
+                  <tr>
+                    <th scope="col" class="px-2 text-center text-nowrap">順位</th>
+                    <th scope="col" class="px-2 text-center text-nowrap">名前</th>
+                    <th scope="col" class="px-2 text-center text-nowrap"><%= result_label(table) %></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <%= render partial: "ranking_table", collection: datas.to_a[0..11], as: "data" %>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/graphs/_collapse.html.erb
+++ b/app/views/graphs/_collapse.html.erb
@@ -1,11 +1,11 @@
 <div class="col-12 col-sm-6 col-md-3 p-0">
   <%= pie_chart datas.to_a[0..2], title: title, label: result_label(table), suffix: suffix_name(table) %>
   <p class="d-flex justify-content-center m-0">
-    <button class="btn btn-outline-secondary btn-block" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>"><i class="fas fa-list-ul fa-lg pr-2"></i>詳細</button>
+    <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
   </p>
   <div class="row">
     <div class="col">
-      <div class="collapse multi-collapse" id="<%= table %>">
+      <div class="collapse multi-collapse ranking-collapse" id="<%= table %>">
         <div class="card">
           <table class="table m-0">
             <thead>

--- a/app/views/graphs/_collapse.html.erb
+++ b/app/views/graphs/_collapse.html.erb
@@ -1,0 +1,26 @@
+<div class="col-12 col-sm-6 col-md-3 p-0">
+  <%= pie_chart datas.to_a[0..2], title: title, label: result_label(table), suffix: suffix_name(table) %>
+  <p class="d-flex justify-content-center m-0">
+    <button class="btn btn-outline-secondary btn-block" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>"><i class="fas fa-list-ul fa-lg pr-2"></i>詳細</button>
+  </p>
+  <div class="row">
+    <div class="col">
+      <div class="collapse multi-collapse" id="<%= table %>">
+        <div class="card">
+          <table class="table m-0">
+            <thead>
+              <tr>
+                <th scope="col" class="px-2 text-center text-nowrap">順位</th>
+                <th scope="col" class="px-2 text-center text-nowrap">名前</th>
+                <th scope="col" class="px-2 text-center text-nowrap"><%= result_label(table) %></th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= render partial: "ranking_table", collection: datas.to_a[0..11], as: "data" %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/graphs/_ranking_table.html.erb
+++ b/app/views/graphs/_ranking_table.html.erb
@@ -1,5 +1,12 @@
-<tr class="rank-color-<%= data_counter + 1 %>">
-  <td class="text-center"><%= data_counter + 1 %></td>
-  <td class="text-center"><%= data[0] %></td>
-  <td class="text-center"><%= data[1].round(1) %></td>
-</tr> 
+<% ranking = 0 %>
+<% before_data = nil %>
+<% datas.each do |data| %>
+  <% before_data != data[1].round(1) ? ranking += 1 : ranking %>
+  <% break if ranking > 12 %>
+  <tr class="rank-color-<%= ranking %>">
+    <td class="text-center"><%= ranking %></td>
+    <td class="text-center"><%= data[0] %></td>
+    <td class="text-center"><%= data[1].round(1) %></td>
+  </tr>  
+  <% before_data = data[1].round(1) %>
+<% end %> 

--- a/app/views/graphs/_ranking_table.html.erb
+++ b/app/views/graphs/_ranking_table.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr class="rank-color-<%= data_counter + 1 %>">
   <td class="text-center"><%= data_counter + 1 %></td>
   <td class="text-center"><%= data[0] %></td>
   <td class="text-center"><%= data[1].round(1) %></td>

--- a/app/views/graphs/_ranking_table.html.erb
+++ b/app/views/graphs/_ranking_table.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= data_counter + 1 %></td>
-  <td><%= data[0] %></td>
-  <td><%= data[1].round(1) %></td>
+  <td class="text-center"><%= data_counter + 1 %></td>
+  <td class="text-center"><%= data[0] %></td>
+  <td class="text-center"><%= data[1].round(1) %></td>
 </tr> 

--- a/app/views/graphs/_ranking_table.html.erb
+++ b/app/views/graphs/_ranking_table.html.erb
@@ -1,0 +1,5 @@
+<tr>
+  <td><%= data_counter + 1 %></td>
+  <td><%= data[0] %></td>
+  <td><%= data[1].round(1) %></td>
+</tr> 

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,0 +1,17 @@
+<div class="row px-3">
+  <div class="col-12 col-sm-6 col-md-3 p-0">
+    <%= pie_chart @tags_count_graph.to_a[0..2], title: "タグ別使用投稿数" %>
+  </div>
+  <div class="col-12 col-sm-6 col-md-3 p-0">
+    <%= pie_chart @categories_count_graph.to_a[0..2], title: "カテゴリー別使用投稿数" %>
+  </div>
+  <div class="col-12 col-sm-6 col-md-3 p-0">
+    <%= pie_chart @likes_count_graph.to_a[0..2], title: "いいね総合獲得数", suffix: "いいね !" %>
+  </div>
+  <div class="col-12 col-sm-6 col-md-3 p-0">
+    <%= pie_chart @likes_average_graph.to_a[0..2], title: "平均いいね獲得数", label: "平均", suffix: "いいね !" %>
+  </div>
+</div>
+<div class="d-flex justify-content-end text-muted">
+  <small>＊グラフは TOP3 まで表示しています＊</small>
+</div>

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,3 +1,8 @@
+<div class="title-group">
+  <h1>Data</h1>
+  <p class="sub-title mb-0">データ</p>
+</div>
+<hr class="devise-link mt-0 mb-5">
 <div class="d-flex justify-content-end text-muted">
   <small class="mb-3">＊グラフは TOP3 まで表示しています＊</small>
 </div>

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,9 +1,9 @@
 <div class="d-flex justify-content-end text-muted">
-  <small>＊グラフは TOP3 まで表示しています＊</small>
+  <small class="mb-3">＊グラフは TOP3 まで表示しています＊</small>
 </div>
 <div class="row px-3">
   <%= render "collapse", datas: @tags_count_graph, table: "tags-count", title: "タグ別使用投稿数" %>
-  <%= render "collapse", datas: @categories_count_graph, table: "categories-count", title: "カテゴリー別使用投稿数" %>
+  <%= render "collapse", datas: @categories_count_graph, table: "categories-count", title: "カテゴリ別使用投稿数" %>
   <%= render "collapse", datas: @likes_count_graph, table: "likes-count", title: "いいね総合獲得数" %>
   <%= render "collapse", datas: @likes_average_graph, table: "likes-average", title: "平均いいね獲得数" %>
 </div>

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -2,8 +2,8 @@
   <small>＊グラフは TOP3 まで表示しています＊</small>
 </div>
 <div class="row px-3">
-  <%= render "collapse", datas: @tags_count_graph, table: "tags_count", title: "タグ別使用投稿数" %>
-  <%= render "collapse", datas: @categories_count_graph, table: "categories_count", title: "カテゴリー別使用投稿数" %>
-  <%= render "collapse", datas: @likes_count_graph, table: "likes_count", title: "いいね総合獲得数" %>
-  <%= render "collapse", datas: @likes_average_graph, table: "likes_average", title: "平均いいね獲得数" %>
+  <%= render "collapse", datas: @tags_count_graph, table: "tags-count", title: "タグ別使用投稿数" %>
+  <%= render "collapse", datas: @categories_count_graph, table: "categories-count", title: "カテゴリー別使用投稿数" %>
+  <%= render "collapse", datas: @likes_count_graph, table: "likes-count", title: "いいね総合獲得数" %>
+  <%= render "collapse", datas: @likes_average_graph, table: "likes-average", title: "平均いいね獲得数" %>
 </div>

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,17 +1,9 @@
-<div class="row px-3">
-  <div class="col-12 col-sm-6 col-md-3 p-0">
-    <%= pie_chart @tags_count_graph.to_a[0..2], title: "タグ別使用投稿数" %>
-  </div>
-  <div class="col-12 col-sm-6 col-md-3 p-0">
-    <%= pie_chart @categories_count_graph.to_a[0..2], title: "カテゴリー別使用投稿数" %>
-  </div>
-  <div class="col-12 col-sm-6 col-md-3 p-0">
-    <%= pie_chart @likes_count_graph.to_a[0..2], title: "いいね総合獲得数", suffix: "いいね !" %>
-  </div>
-  <div class="col-12 col-sm-6 col-md-3 p-0">
-    <%= pie_chart @likes_average_graph.to_a[0..2], title: "平均いいね獲得数", label: "平均", suffix: "いいね !" %>
-  </div>
-</div>
 <div class="d-flex justify-content-end text-muted">
   <small>＊グラフは TOP3 まで表示しています＊</small>
+</div>
+<div class="row px-3">
+  <%= render "collapse", datas: @tags_count_graph, table: "tags_count", title: "タグ別使用投稿数" %>
+  <%= render "collapse", datas: @categories_count_graph, table: "categories_count", title: "カテゴリー別使用投稿数" %>
+  <%= render "collapse", datas: @likes_count_graph, table: "likes_count", title: "いいね総合獲得数" %>
+  <%= render "collapse", datas: @likes_average_graph, table: "likes_average", title: "平均いいね獲得数" %>
 </div>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -14,7 +14,7 @@
       </button>
       <%# 要素を右寄せで配置 %>
       <div class="navbar-nav ml-auto">
-        <%= link_to "#", class: "nav-item nav-link" do %>
+        <%= link_to graphs_path, class: "nav-item nav-link" do %>
           <i class="fas fa-chart-pie"></i> データ
         <% end %>
         <%= link_to "#", class: "nav-item nav-link" do %>
@@ -41,7 +41,7 @@
         <%= link_to new_user_session_path, class: "nav-item nav-link" do %>
           <i class="fas fa-sign-in-alt"></i> ログイン
         <% end %>
-        <%= link_to "#", class: "nav-item nav-link" do %>
+        <%= link_to graphs_path, class: "nav-item nav-link" do %>
           <i class="fas fa-chart-pie"></i> データ
         <% end %>
         <%= link_to "#", class: "nav-item nav-link" do %>

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,0 +1,50 @@
+Chartkick.options = {
+  width: '100%',
+  colors: [ "#baa877",
+            "#a8a9a8",
+            "#947b60",
+            "#E6E7E8",
+            "#E8E9EB",
+            "#EBECED",
+            "#EDEFF0",
+            "#F0F1F2",
+            "#F2F4F5",
+            "#F5F6F7",
+            "#F7F9FA",
+            "#FCFEFF",
+          ],
+  label: "合計",
+  loading: "Loading...",
+  thousands: ",",
+  suffix: "件",
+  round: 1,
+  legend: false,
+  library: {
+    title: {
+      align: 'center',
+      verticalAlign: 'bottom'
+    },
+    chart: {
+      backgroundColor: 'none',
+      plotBorderWidth: 0,
+      plotShadow: false
+    },
+    plotOptions: {
+      pie: {
+        cursor: 'pointer',
+        dataLabels: {
+          enabled: true,
+          distance: -40,
+          allowOverlap: false, # ラベルが重なったとき非表示にする
+          style: {
+            textAlign: 'center',
+            textOutline: 0
+          }
+        },
+        size: '110%',
+        borderWidth: 1,
+        borderColor: "#d3d3d3"
+      }
+    }
+  }
+}

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,22 +1,21 @@
 Chartkick.options = {
   width: '100%',
-  colors: [ "#baa877",
-            "#a8a9a8",
-            "#947b60",
-            "#E6E7E8",
-            "#E8E9EB",
-            "#EBECED",
-            "#EDEFF0",
-            "#F0F1F2",
-            "#F2F4F5",
-            "#F5F6F7",
-            "#F7F9FA",
-            "#FCFEFF",
-          ],
-  label: "合計",
-  loading: "Loading...",
-  thousands: ",",
-  suffix: "件",
+  colors: ['#baa877',
+           '#a8a9a8',
+           '#947b60',
+           '#E6E7E8',
+           '#E8E9EB',
+           '#EBECED',
+           '#EDEFF0',
+           '#F0F1F2',
+           '#F2F4F5',
+           '#F5F6F7',
+           '#F7F9FA',
+           '#FCFEFF'],
+  label: '合計',
+  loading: 'Loading...',
+  thousands: ',',
+  suffix: '件',
   round: 1,
   legend: false,
   library: {
@@ -43,7 +42,7 @@ Chartkick.options = {
         },
         size: '110%',
         borderWidth: 1,
-        borderColor: "#d3d3d3"
+        borderColor: '#d3d3d3'
       }
     }
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
     resource :likes, only: %i[create destroy]
     resource :marks, only: %i[create destroy]
   end
+  resources :graphs, only: %i[index]
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,66 +18,47 @@ content = 'コメント内容を表示します'
 tags = ['キッチン', 'リビング', 'バス', 'トイレ', 'バルコニー', '洗面台', '寝室', '洋室', '和室', '子供部屋', '玄関', 'その他']
 categories = ['成功', '失敗', 'おすすめ', 'DIY', '紹介', 'その他']
 
+%w[users posts photos tags categories post_tags post_categories likes marks].each do |table_name|
+  ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+end
+
+tags.each { |tag| Tag.create!(name: tag) }
+puts 'タグの初期データインポートに成功しました。'
+
+categories.each { |category| Category.create!(name: category) }
+puts 'カテゴリーの初期データインポートに成功しました。'
+
 User.find_or_create_by!(email: email) do |user|
   user.name = name
   user.password = password
   user.age = age
   user.address = address
   user.household = household
-  puts 'ユーザーの初期データインポートに成功しました。'
+  puts 'テストユーザーの初期データインポートに成功しました。'
 end
 
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE tags RESTART IDENTITY CASCADE')
-tags.each do |tag|
-  Tag.create!(name: tag)
+1000.times do
+  User.create!(
+    name: Faker::Name.name,
+    email: Faker::Internet.email,
+    password: Faker::Internet.password,
+    age: age,
+    address: address,
+    household: household
+  )
 end
-puts 'タグの初期データインポートに成功しました。'
+puts 'ユーザーの初期データ 1000 件のインポートに成功しました。'
 
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE categories RESTART IDENTITY CASCADE')
-categories.each do |category|
-  Category.create!(name: category)
+1000.times do
+  post = Post.create!(
+    content: Faker::Lorem.paragraph(sentence_count: 100),
+    user_id: rand(1..100)
+  )
+  post.photos.create!(image: image)
+  post.post_tags.create!(tag_id: rand(1..12))
+  post.post_categories.create!(category_id: rand(1..6))
+  post.comments.create!(content: content, user_id: rand(1..100))
+  post.likes.create!(user_id: rand(1..100))
+  post.marks.create!(user_id: rand(1..100))
 end
-puts 'カテゴリーの初期データインポートに成功しました。'
-
-# テスト投稿の初期データ
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE posts RESTART IDENTITY CASCADE')
-post1 = Post.create!(content: 'テスト', user_id: 1)
-post2 = Post.create!(content: 'テスト<br>テスト', user_id: 1)
-post3 = Post.create!(content: '<h1>テスト</h1>', user_id: 1)
-puts '投稿内容の初期データインポートに成功しました。'
-
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE photos RESTART IDENTITY CASCADE')
-post1.photos.create!(image: image)
-post2.photos.create!(image: image)
-post3.photos.create!(image: image)
-puts '投稿画像の初期データインポートに成功しました。'
-
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE comments RESTART IDENTITY CASCADE')
-post1.comments.create!(content: content, user_id: 1)
-post2.comments.create!(content: content, user_id: 1)
-post3.comments.create!(content: content, user_id: 1)
-puts 'コメントの初期データインポートに成功しました。'
-
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE post_tags RESTART IDENTITY CASCADE')
-post1.post_tags.create!(tag_id: 1)
-post2.post_tags.create!(tag_id: 2)
-post3.post_tags.create!(tag_id: 3)
-puts '投稿タグの初期データインポートに成功しました。'
-
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE post_categories RESTART IDENTITY CASCADE')
-post1.post_categories.create!(category_id: 1)
-post2.post_categories.create!(category_id: 2)
-post3.post_categories.create!(category_id: 3)
-puts '投稿カテゴリーの初期データインポートに成功しました。'
-
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE likes RESTART IDENTITY CASCADE')
-post1.likes.create!(user_id: 1)
-post2.likes.create!(user_id: 1)
-post3.likes.create!(user_id: 1)
-puts 'いいねの初期データインポートに成功しました。'
-
-ActiveRecord::Base.connection.execute('TRUNCATE TABLE marks RESTART IDENTITY CASCADE')
-post1.marks.create!(user_id: 1)
-post2.marks.create!(user_id: 1)
-post3.marks.create!(user_id: 1)
-puts 'マークの初期データインポートに成功しました。'
+puts '投稿の初期データ 1000 件のインポートに成功しました。'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,8 +57,8 @@ puts 'ユーザーの初期データ 1000 件のインポートに成功しま�
   post.photos.create!(image: image)
   post.post_tags.create!(tag_id: rand(1..12))
   post.post_categories.create!(category_id: rand(1..6))
-  post.comments.create!(content: content, user_id: rand(1..100))
-  post.likes.create!(user_id: rand(1..100))
-  post.marks.create!(user_id: rand(1..100))
+  post.comments.create!(content: content, user_id: rand(1..1000))
+  post.likes.create!(user_id: rand(1..1000))
+  post.marks.create!(user_id: rand(1..1000))
 end
 puts '投稿の初期データ 1000 件のインポートに成功しました。'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bootstrap": "~4.5.1",
     "chart.js": "^3.6.1",
     "chartkick": "^4.1.1",
+    "highcharts": "^9.3.2",
     "jquery": "^3.6.0",
     "jscroll": "^2.4.1",
     "popper.js": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.0",
     "bootstrap": "~4.5.1",
+    "chart.js": "^3.6.1",
+    "chartkick": "^4.1.1",
     "jquery": "^3.6.0",
     "jscroll": "^2.4.1",
     "popper.js": "^1.16.1",

--- a/spec/requests/graphs_spec.rb
+++ b/spec/requests/graphs_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Graphs", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/graphs/index"
+RSpec.describe 'Graphs', type: :request do
+  describe 'GET /index' do
+    it 'returns http success' do
+      get '/graphs/index'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/graphs_spec.rb
+++ b/spec/requests/graphs_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Graphs", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/graphs/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,25 @@ chalk@^2.0, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chart.js@>=3.0.2, chart.js@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.6.1.tgz#edcb6584b8d810306f655f89538c00a4f440c58e"
+  integrity sha512-AycnixR0I325Fp3bqQ7wRJbkIJPwz/9IZtUBvdBWMjK5+nKCy6FZ3VejkDTtB9udePEXNt1UYoGTsNL49JoIbg==
+
+chartjs-adapter-date-fns@>=2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-2.0.0.tgz#5e53b2f660b993698f936f509c86dddf9ed44c6b"
+  integrity sha512-rmZINGLe+9IiiEB0kb57vH3UugAtYw33anRiw5kS2Tu87agpetDDoouquycWc9pRsKtQo5j+vLsYHyr8etAvFw==
+
+chartkick@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-4.1.1.tgz#60d6e13a090c5334bd80ad8fb7da02aaf38fb936"
+  integrity sha512-+3+dIKZo8MzOiQFc4FZDZiRjDnrgVxgjk3tKXVclMcDF8yIJAEqSr5/l4pqpB2Rxye1s2Dg3j6bVA9eIeDbnCQ==
+  optionalDependencies:
+    chart.js ">=3.0.2"
+    chartjs-adapter-date-fns ">=2.0.0"
+    date-fns ">=2.0.0"
+
 "chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
@@ -2313,6 +2332,11 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+date-fns@>=2.0.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
+  integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3219,6 +3219,11 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+highcharts@^9.3.2:
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-9.3.2.tgz#20b34f7277169a48d7b5691f74705e8addc78cd3"
+  integrity sha512-I/48gNMvs3hZxZnPRUqLbnlrGZJJ7YPPVr1+fYeZ35p4pSZAOwTmAGbptrjBr7JlF52HmJH9zMbt/I4TPLu9Pg==
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"


### PR DESCRIPTION
close #23
  
## 実装内容
- gem`cartkick` を導入
  - `highcharts`を使用して円グラフを作成
- `config/initializers/chartkick.rb`を作成して`heigcharts`の`オプション`を設定
- `graphs`コントローラを作成
  - `index`アクションのみ作成
- ルーティングを設定
  - `index`のみ設定
- ナビバーに`データ集計ページ`へのリンクを作成
- `graph.js`ファイルを作成
- 各ランキングの TOP3 を`円グラフ`で表示
  - `タグ別使用件数`, `カテゴリ別使用件数`, `いいね総合獲得数`, `平均いいね獲得数`
  - 各順位の一番初めの投稿の`名前のみ`を表示する(同率が多いと見づらくなるため)
- ランキングのテーブルをコラプスで表示
  - 画面サイズが`lg`以上の場合はコラプスを開く
  - コラプスの開閉状態で`ボタンの色`、`ボタンのアイコン`を切り替える
  - 値が同じ場合は同率順位で表示する
  - TOP3は円グラフの順位と`同色で背景色`を設定する(見てすぐ順位がわかるようにするため)
- ユーザーページへ遷移した際に、画面サイズが`sm`以下の場合投稿一覧に`jscroll`を適用するように修正
- `db/seeds.rb`にユーザー・投稿ともにランダムに`1000 件`作成できるように処理を修正
  
## 動作確認
- [x] ローカル環境での動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行