### PR TITLE
アカウント画像アップロード機能の修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,9 +54,10 @@ button.close, button.navbar-toggler {
 
 .avatar-container {
   position: relative;
-  height: 200px;
-  width: 200px;
+  max-width: 200px;
   .avatar-label {
+    position: absolute;
+    top: 0;
     height: 200px;
     width: 200px;
     background-image: url("/images/fallback/default.png");
@@ -69,6 +70,19 @@ button.close, button.navbar-toggler {
       width: 200px;
     }
   }
+  .avatar-preview {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.avatar-container::before {
+  content: "";
+  display: block;
+  padding-top: 100%;
 }
 
 a:hover {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,9 +52,23 @@ button.close, button.navbar-toggler {
     outline: none;
   }
 
-#preview {
+.avatar-container {
+  position: relative;
   height: 200px;
   width: 200px;
+  .avatar-label {
+    height: 200px;
+    width: 200px;
+    background-image: url("/images/fallback/default.png");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    cursor: pointer;
+    .avatar-preview {
+      height: 200px;
+      width: 200px;
+    }
+  }
 }
 
 a:hover {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,12 +65,8 @@ button.close, button.navbar-toggler {
     background-repeat: no-repeat;
     background-size: cover;
     cursor: pointer;
-    .avatar-preview {
-      height: 200px;
-      width: 200px;
-    }
   }
-  .avatar-preview {
+  .user-avatar,.avatar-preview {
     position: absolute;
     top: 0;
     width: 100%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,8 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:avater, :name, :age, :address, :household])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:avater, :name, :age, :address, :household, :favorite_items, :profile])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:avatar, :name, :age, :address, :household])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:avatar, :name, :age, :address, :household, :favorite_items, :profile])
   end
 
   def set_search

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,8 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:avatar, :name, :age, :address, :household])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:avatar, :name, :age, :address, :household, :favorite_items, :profile])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:avatar, :avatar_cache, :name, :age, :address, :household])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:avatar, :avatar_cache, :name, :age, :address, :household, :favorite_items, :profile])
   end
 
   def set_search

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -46,11 +46,11 @@ module Users
       redirect_to user_path(current_user.id), alert: 'ゲストユーザーの削除・更新はできません' if resource.email == 'guest@example.com'
     end
 
-    def after_sign_up_path_for(resource)
+    def after_sign_up_path_for(_resource)
       posts_path
     end
 
-    def after_update_path_for(resource)
+    def after_update_path_for(_resource)
       user_path(current_user)
     end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,11 +40,21 @@ module Users
     #   super
     # end
 
-    # protected
+    private
 
     def ensure_nomal_user
       redirect_to user_path(current_user.id), alert: 'ゲストユーザーの削除・更新はできません' if resource.email == 'guest@example.com'
     end
+
+    def after_sign_up_path_for(resource)
+      posts_path
+    end
+
+    def after_update_path_for(resource)
+      user_path(current_user)
+    end
+
+    # protected
 
     # If you have extra params to permit, append them to the sanitizer.
     # def configure_sign_up_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,7 +26,7 @@ module Users
 
     private
 
-    def after_sign_in_path_for(resource)
+    def after_sign_in_path_for(_resource)
       posts_path
     end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -24,6 +24,12 @@ module Users
     #   super
     # end
 
+    private
+
+    def after_sign_in_path_for(resource)
+      posts_path
+    end
+
     # protected
 
     # If you have extra params to permit, append them to the sanitizer.

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -6,6 +6,7 @@ $(document).on('turbolinks:load', function(){
         function avatarPreview(avatar){
             const fileReader = new FileReader();
             if ($('.avatar-preview').length ) {
+                if ($('#current-avatar-image').length) $('.avatar-label').prepend('<input type="hidden" name="user[avatar]" value="">')
                 dataBox.clearData();
                 $('.avatar-preview, .delete-preview').remove();
             }

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -11,7 +11,6 @@ $(document).on('turbolinks:load', function(){
                 $('.avatar-preview, .delete-preview').remove();
             }
             dataBox.items.add(avatar)
-            fileField.files = dataBox.files
             fileReader.onloadend = function(){
                 const avatarImage = `<img src="${fileReader.result}" class="rounded-circle avatar-preview bg-light">`;
                 const deleteButton = '<button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -1,10 +1,33 @@
-document.addEventListener('turbolinks:load', () => {
-    const previewImage = document.querySelector('.previewImage');
-    previewImage.addEventListener('change', (e) => {
-        const fileReader = new FileReader();
-        fileReader.onload = (function() {
-        document.getElementById('preview').src = fileReader.result;
+$(document).on('turbolinks:load', function(){
+    $(function(){
+        const dataBox = new DataTransfer();
+        const fileField = document.querySelector('input[id=user_avatar]');
+        // 【プロフィール画像プレビュー】
+        $('.avatar-image-field').on('change', function(){
+            if ($(this).val() !== "") {
+                const avatar = $(this).prop('files')[0];
+                const fileReader = new FileReader();
+                if (dataBox.items.length !== 0) {
+                    dataBox.clearData();
+                    $('.avatar-preview, .delete-preview').remove();
+                }
+                dataBox.items.add(avatar)
+                fileField.files = dataBox.files
+                fileReader.onloadend = function(){
+                    const avatarPreview = `<img src="${fileReader.result}" class="rounded-circle avatar-preview bg-light">`;
+                    const deleteButton = '<button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
+                    $('.avatar-label').prepend(avatarPreview).after(deleteButton);
+                };
+                fileReader.readAsDataURL(avatar);
+            } else {
+                fileField.files = dataBox.files
+            }
+        });
+        // 【プロフィール画像削除】
+        $('.avatar-container').on('click', '.delete-preview', function(){
+            dataBox.clearData();
+            fileField.files = dataBox.files
+            $('.avatar-preview, .delete-preview').remove();
+        });
     });
-    fileReader.readAsDataURL(e.target.files[0]);
-    });
-})
+});

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -7,7 +7,7 @@ $(document).on('turbolinks:load', function(){
             if ($(this).val() !== "") {
                 const avatar = $(this).prop('files')[0];
                 const fileReader = new FileReader();
-                if (dataBox.items.length !== 0) {
+                if ($('.avatar-preview').length ) {
                     dataBox.clearData();
                     $('.avatar-preview, .delete-preview').remove();
                 }
@@ -25,8 +25,12 @@ $(document).on('turbolinks:load', function(){
         });
         // 【プロフィール画像削除】
         $('.avatar-container').on('click', '.delete-preview', function(){
-            dataBox.clearData();
-            fileField.files = dataBox.files
+            if($('.avatar-image-field').val()){
+                dataBox.clearData();
+                fileField.files = dataBox.files
+            } else {
+                $('.avatar-label').prepend('<input type="hidden" name="user[avatar]" value="">');
+            }
             $('.avatar-preview, .delete-preview').remove();
         });
     });

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -20,7 +20,7 @@ $(document).on('turbolinks:load', function(){
         }
         // 【プロフィール画像選択】
         $('.avatar-image-field').on('change', function(){
-            if ($(this).val() !== "") {
+            if ($(this).val()) {
                 const avatar = $(this).prop('files')[0];
                 avatarPreview(avatar);
             } else {

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -3,22 +3,26 @@ $(document).on('turbolinks:load', function(){
         const dataBox = new DataTransfer();
         const fileField = document.querySelector('input[id=user_avatar]');
         // 【プロフィール画像プレビュー】
+        function avatarPreview(avatar){
+            const fileReader = new FileReader();
+            if ($('.avatar-preview').length ) {
+                dataBox.clearData();
+                $('.avatar-preview, .delete-preview').remove();
+            }
+            dataBox.items.add(avatar)
+            fileField.files = dataBox.files
+            fileReader.onloadend = function(){
+                const avatarImage = `<img src="${fileReader.result}" class="rounded-circle avatar-preview bg-light">`;
+                const deleteButton = '<button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
+                $('.avatar-label').prepend(avatarImage).after(deleteButton);
+            };
+            fileReader.readAsDataURL(avatar);
+        }
+        // 【プロフィール画像選択】
         $('.avatar-image-field').on('change', function(){
             if ($(this).val() !== "") {
                 const avatar = $(this).prop('files')[0];
-                const fileReader = new FileReader();
-                if ($('.avatar-preview').length ) {
-                    dataBox.clearData();
-                    $('.avatar-preview, .delete-preview').remove();
-                }
-                dataBox.items.add(avatar)
-                fileField.files = dataBox.files
-                fileReader.onloadend = function(){
-                    const avatarPreview = `<img src="${fileReader.result}" class="rounded-circle avatar-preview bg-light">`;
-                    const deleteButton = '<button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
-                    $('.avatar-label').prepend(avatarPreview).after(deleteButton);
-                };
-                fileReader.readAsDataURL(avatar);
+                avatarPreview(avatar);
             } else {
                 fileField.files = dataBox.files
             }
@@ -33,5 +37,23 @@ $(document).on('turbolinks:load', function(){
             }
             $('.avatar-preview, .delete-preview').remove();
         });
+        // 【プロフィール画像ドロップ機能】
+        if (document.querySelector('.avatar-label')) {
+            const avatarDropArea = document.querySelector('.avatar-label');
+            avatarDropArea.addEventListener("dragover", function(e){
+                e.preventDefault();
+                $(this).css({'background-color': '#9e9e9e', 'opacity': '0.5'});
+            },false);
+            avatarDropArea.addEventListener("dragleave", function(e){
+                e.preventDefault();
+                $(this).css('opacity', '1.0').addClass('bg-light');
+            },false);
+            avatarDropArea.addEventListener("drop", function(e) {
+                e.preventDefault();
+                $(this).css('opacity', '1.0').addClass('bg-light');
+                const avatar = e.dataTransfer.files[0];
+                avatarPreview(avatar);
+            });
+        }
     });
 });

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,5 +4,5 @@ class Comment < ApplicationRecord
   validates :content, presence: true, length: { maximum: 140 }
 
   # user  モデルの name と avater を委譲する
-  delegate :name, :avater, to: :user, prefix: true
+  delegate :name, :avatar, to: :user, prefix: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,7 +12,7 @@ class Post < ApplicationRecord
   has_many :marked_users, through: :marks, source: :user
 
   # user モデルの name を委譲する
-  delegate :name, :avater, :id, to: :user, prefix: true
+  delegate :name, :avatar, :id, to: :user, prefix: true
 
   def liked_by?(current_user)
     likes.any? { |like| like.user_id == current_user.id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   validates :household, presence: true
 
   # AvaterUploader と users テーブルの avater カラムを連携
-  mount_uploader :avater, AvaterUploader
+  mount_uploader :avatar, AvatarUploader
 
   enum age: {
     teens: 1,

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,4 +1,4 @@
-class AvaterUploader < CarrierWave::Uploader::Base
+class AvatarUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   # include CarrierWave::MiniMagick

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,5 +1,5 @@
 <div class="comment-user py-2 d-flex" id="comment-<%= comment.id %>">
-  <%= image_tag comment.user_avater.url, class: "rounded-circle", size: "24x24" %>
+  <%= image_tag comment.user_avatar.url, class: "rounded-circle", size: "24x24" %>
   <div class="flex-column">
     <div class="font-weight-bold">
       <%= comment.user_name %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,6 +11,7 @@
     <%= f.label :avatar do %>
       <p><%= image_tag @user.avatar.url, class: "rounded-circle", id: 'preview' %></p>
       <%= f.file_field :avatar, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
+      <%= f.hidden_field :avatar_cache %>
     <% end %>
   </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,9 +8,9 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :avater do %>
-      <p><%= image_tag @user.avater.url, class: "rounded-circle", id: 'preview' %></p>
-      <%= f.file_field :avater, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
+    <%= f.label :avatar do %>
+      <p><%= image_tag @user.avatar.url, class: "rounded-circle", id: 'preview' %></p>
+      <%= f.file_field :avatar, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
     <% end %>
   </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,7 +10,7 @@
   <div class="form-group">
     <div class="avatar-container">
       <%= f.label :avatar, class: "avatar-label rounded-circle" do %>
-        <%= image_tag @user.avatar.url, class: "rounded-circle avatar-preview bg-light" %>
+        <%= image_tag @user.avatar.url, class: "rounded-circle avatar-preview bg-light", id: "current-avatar-image" %>
         <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
         <%= f.hidden_field :avatar_cache %>
       <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,11 +8,16 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :avatar do %>
-      <p><%= image_tag @user.avatar.url, class: "rounded-circle", id: 'preview' %></p>
-      <%= f.file_field :avatar, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
-      <%= f.hidden_field :avatar_cache %>
-    <% end %>
+    <div class="avatar-container">
+      <%= f.label :avatar, class: "avatar-label rounded-circle" do %>
+        <%= image_tag @user.avatar.url, class: "rounded-circle avatar-preview bg-light" %>
+        <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
+        <%= f.hidden_field :avatar_cache %>
+      <% end %>
+      <% if @user.avatar? %>
+        <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>
+      <% end %>
+    </div>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,11 +8,12 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :avatar do %>
-      <p><%= image_tag @user.avatar.url, class: "rounded-circle", id: 'preview'%></p>
-      <%= f.file_field :avatar, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;'%>
-      <%= f.hidden_field :avatar_cache %>
-    <% end %>
+    <div class="avatar-container">
+      <%= f.label :avatar, class: "avatar-label rounded-circle" do %>
+        <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;'%>
+        <%= f.hidden_field :avatar_cache %>
+      <% end %>
+    </div>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,6 +11,7 @@
     <%= f.label :avatar do %>
       <p><%= image_tag @user.avatar.url, class: "rounded-circle", id: 'preview'%></p>
       <%= f.file_field :avatar, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;'%>
+      <%= f.hidden_field :avatar_cache %>
     <% end %>
   </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,9 +8,9 @@
   <%= bootstrap_devise_error_messages! %>
 
   <div class="form-group">
-    <%= f.label :avater do %>
-      <p><%= image_tag @user.avater.url, class: "rounded-circle", id: 'preview'%></p>
-      <%= f.file_field :avater, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;'%>
+    <%= f.label :avatar do %>
+      <p><%= image_tag @user.avatar.url, class: "rounded-circle", id: 'preview'%></p>
+      <%= f.file_field :avatar, class: 'previewImage', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;'%>
     <% end %>
   </div>
 

--- a/app/views/posts/_time_line.html.erb
+++ b/app/views/posts/_time_line.html.erb
@@ -12,7 +12,7 @@
           <div class="card-body d-flex flex-column h-100 p-0">
             <div class="card-name text-truncate p-3">
               <%= link_to user_path(post.user_id), class: 'text-reset' do %>
-                <%= image_tag post.user_avater.url, class: "rounded-circle", size: "32x32" %>
+                <%= image_tag post.user_avatar.url, class: "rounded-circle", size: "32x32" %>
                 <span class="pl-2">
                   <%= post.user_name %>
                 </span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -41,7 +41,7 @@
           <div class="card-body d-flex flex-column h-100 p-0">
             <div class="card-name d-flex p-3">
             <%= link_to user_path(@post.user_id), class: "d-flex text-reset" do %>
-              <%= image_tag @post.user_avater.url, class: "rounded-circle", size: "32x32" %>
+              <%= image_tag @post.user_avatar.url, class: "rounded-circle", size: "32x32" %>
               <div class="font-weight-bold pl-2">
                 <%= @post.user_name %>
               </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,8 +6,10 @@
 </div>
 <div class="row">
   <div class="col-12 col-md-6 d-flex flex-column h-100">
-    <div class="col-3 col-md-4 d-flex flex-row p-0">
-      <%= image_tag @user.avatar.url, class: "img-fluid rounded-circle avatar-preview bg-light mb-4" %>
+    <div class="row m-0">
+      <div class="col-3 col-md-4 avatar-container p-0 mb-4">
+        <%= image_tag @user.avatar.url, class: "rounded-circle avatar-preview bg-light" %>
+      </div>
     </div>
     <div class="d-flex font-weight-bold border-bottom user-name mb-3">
       <%= @user.name %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
   <div class="col-12 col-md-6 d-flex flex-column h-100">
     <div class="row m-0">
       <div class="col-3 col-md-4 avatar-container p-0 mb-4">
-        <%= image_tag @user.avatar.url, class: "rounded-circle avatar-preview bg-light" %>
+        <%= image_tag @user.avatar.url, class: "rounded-circle user-avatar bg-light" %>
       </div>
     </div>
     <div class="d-flex font-weight-bold border-bottom user-name mb-3">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
 <div class="row">
   <div class="col-12 col-md-6 d-flex flex-column h-100">
     <div class="col-3 col-md-4 d-flex flex-row p-0">
-      <%= image_tag @user.avater.url, class: "img-fluid rounded-circle mb-4", width: "200px", height: "200px" %>
+      <%= image_tag @user.avatar.url, class: "img-fluid rounded-circle mb-4", width: "200px", height: "200px" %>
     </div>
     <div class="d-flex font-weight-bold border-bottom user-name mb-3">
       <%= @user.name %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
 <div class="row">
   <div class="col-12 col-md-6 d-flex flex-column h-100">
     <div class="col-3 col-md-4 d-flex flex-row p-0">
-      <%= image_tag @user.avatar.url, class: "img-fluid rounded-circle mb-4", width: "200px", height: "200px" %>
+      <%= image_tag @user.avatar.url, class: "img-fluid rounded-circle avatar-preview bg-light mb-4" %>
     </div>
     <div class="d-flex font-weight-bold border-bottom user-name mb-3">
       <%= @user.name %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -25,7 +25,7 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
-        avater: プロフィール画像
+        avatar: プロフィール画像
         name: ユーザーネーム
         age: 年代
         address: お住まい

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations',
+    sessions: 'users/sessions',
     passwords: 'users/passwords'
   }
   devise_scope :user do

--- a/db/migrate/20220113173201_rename_avater_column_to_users.rb
+++ b/db/migrate/20220113173201_rename_avater_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameAvaterColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :users, :avater, :avatar
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_042449) do
+ActiveRecord::Schema.define(version: 2022_01_13_173201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,7 +107,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_042449) do
     t.integer "age", default: 0, null: false
     t.integer "address", default: 0, null: false
     t.text "profile"
-    t.string "avater"
+    t.string "avatar"
     t.string "favorite_items"
     t.integer "household", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
close #58
  
## 実装内容
- users  テーブルのカラム名 `avater` を `avatar` に修正
- 全てのファイルのカラム名 `avatar` を修正
- バリデーションが失敗した際のファイルを保持できるようにする
  - `avatar_cache`を使用
- プロフィール画像選択にドラッグ&ドロップ機能を設定
  - ドラッグ&ドロップまたはファイルから選択する際の処理を関数を使って共通化
- 新規登録・アカウント編集ページのプロフィール画像選択に画像削除ボタンを非同期で実装
- ログイン・新規登録・アカウント情報更新後のリダイレクト先を変更
  - 新規登録・ログイン時はタイムラインページへリダイレクト
  - アカウント情報更新後はユーザーページへリダイレクト
  - メソッドの引数は使用しないため先頭に`_`をつけて表示( rubocop に指摘を受ける )

## 動作確認
- [x] ローカルでの動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行