### PR TITLE
Item モデル・テーブルを作成

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,4 @@
+class Item < ApplicationRecord
+  belongs_to :user
+  validates :name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_many :liked_posts, through: :likes, source: :post
   has_many :marks, dependent: :destroy
   has_many :marked_posts, through: :marks, source: :post
+  has_many :items, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 30 }
   validates :age, presence: true

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
       comment: コメント
       like: いいね
       mark: マーク
+      item: アイテム
     attributes:
       post:
         content: 投稿内容
@@ -20,6 +21,11 @@ ja:
       mark:
         user: ユーザー
         post: 投稿
+      item:
+        name: アイテム名
+        genre: ジャンル
+        image: アイテム画像
+        user: ユーザー
   views:
     pagination:
       first: "&laquo;"

--- a/db/migrate/20220122160130_create_items.rb
+++ b/db/migrate/20220122160130_create_items.rb
@@ -1,0 +1,12 @@
+class CreateItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :items do |t|
+      t.string :name, null: false
+      t.string :ganre
+      t.string :image
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_13_173201) do
+ActiveRecord::Schema.define(version: 2022_01_22_160130) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,16 @@ ActiveRecord::Schema.define(version: 2022_01_13_173201) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "ganre"
+    t.string "image"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -116,6 +126,7 @@ ActiveRecord::Schema.define(version: 2022_01_13_173201) do
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "items", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "marks", "posts"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :item do
-    name { "MyString" }
-    ganre { "MyString" }
-    image { "MyString" }
+    name { 'MyString' }
+    ganre { 'MyString' }
+    image { 'MyString' }
     user { nil }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :item do
+    name { "MyString" }
+    ganre { "MyString" }
+    image { "MyString" }
+    user { nil }
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #19
  
## 実装内容
- `Item モデル`を作成
  - `User モデル`との関連付け
  - `name`(アイテム名)
    - `NOT NULL 制約`、`空文字禁止`のバリデーションを設定
  - `genre`(ジャンル)
  - `image`(アイテム画像)
- `Item モデル`の日本語化
  
## 動作確認
- [x] コンソールで日本語訳を確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行