### PR TITLE
Inquiry モデル・テーブルの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
   gem 'web-console', '>= 4.1.0'
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  gem 'letter_opener_web', '~> 2.0'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,15 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -347,6 +356,7 @@ DEPENDENCIES
   gon
   jbuilder (~> 2.7)
   kaminari
+  letter_opener_web (~> 2.0)
   listen (~> 3.3)
   mini_magick
   pg (~> 1.1)

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -1,0 +1,8 @@
+class Inquiry < ApplicationRecord
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :name, presence: true, length: { maximum: 48 }
+  validates :name_kana, presence: true, length: { maximum: 48 }
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, length: { maximum: 256 }
+  validates :content, presence: true, length: { maximum: 2000 }
+  validates :remote_ip, presence: true
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,7 @@ ja:
       like: いいね
       mark: マーク
       item: アイテム
+      inquiry: お問い合わせ
     attributes:
       post:
         content: 投稿内容
@@ -26,6 +27,12 @@ ja:
         genre: ジャンル
         image: アイテム画像
         user: ユーザー
+      inquiry:
+        name: お客様のお名前
+        name_kana: お客様のお名前(カナ)
+        email: メールアドレス
+        content: お問い合わせ内容
+        remote_ip: IPアドレス
   views:
     pagination:
       first: "&laquo;"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions',

--- a/db/migrate/20220203053310_create_inquiries.rb
+++ b/db/migrate/20220203053310_create_inquiries.rb
@@ -1,0 +1,13 @@
+class CreateInquiries < ActiveRecord::Migration[6.1]
+  def change
+    create_table :inquiries do |t|
+      t.string :name, null: false
+      t.string :name_kana, null: false
+      t.string :email, null: false
+      t.text :content, null: false
+      t.inet :remote_ip
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :inquiry do
+    name { "MyString" }
+    name_kana { "MyString" }
+    email { "MyString" }
+    content { "MyText" }
+    remote_ip { "" }
+  end
+end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Inquiry, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #26
  
## 実装内容
-`Inquiry`モデルを作成
  - `name`,`name_kana`,`email`,`content`,`remote_ip`カラムを作成
  - 日本語訳を設定
- gem `'letter_opener_web', '~> 2.0'` をインストール
  - 開発環境でのメール送信機能をブラウザで確認するため

## 動作確認
- [x] `rails c -s`でバリデーション・制約が聞いているか確認
- [x] エラーメッセージが日本語で表示されるか確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行