### PR TITLE
タイムラインの表示を無限スクロールで実装

### DIFF
--- a/app/javascript/packs/jscroll.js
+++ b/app/javascript/packs/jscroll.js
@@ -18,6 +18,8 @@ $(document).on('turbolinks:load', function(){
         $(`#${jscrollId}`).jscroll(Option);
       }
 
+      // タイムラインの表示に jscroll を使用
+      jscrollOption('jscroll-timeline');
       // マイアイテムの表示に jscroll を使用
       jscrollOption('item-list');
       // ユーザーページアクセス時にアクティブ状態のタブに jscroll を設定

--- a/app/javascript/packs/jscroll.js
+++ b/app/javascript/packs/jscroll.js
@@ -21,7 +21,7 @@ $(document).on('turbolinks:load', function(){
       // タイムラインの表示に jscroll を使用
       jscrollOption('jscroll-timeline');
       // マイアイテムの表示に jscroll を使用
-      jscrollOption('item-list');
+      jscrollOption('jscroll-item');
       // ユーザーページアクセス時にアクティブ状態のタブに jscroll を設定
       jscrollOption('list-posts');
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -22,7 +22,7 @@
   </div>
 </div>
 <% if @items.present? %>
-  <div id="item-list">
+  <div id="jscroll-item">
     <ul class="row bg-white py-3 px-0 mb-0 my-items">
       <%= render @items %>
     </ul>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,7 @@
       <p class="text-center text-muted">タイムライン</p>
     </div>
   </div>
-  <div class="jscroll">
+  <div id="jscroll-timeline">
     <div class="row" id="timeline">
       <%= render partial: "time_line", collection: @posts, as: "post" %>
     </div>


### PR DESCRIPTION
close #126
  
## 実装内容
- 画面サイズが`sm`以下の場合のみタイムラインの表示を`無限スクロール`で実装
  - `jscroll`で実装
- マイアイテムのスクロール表示に設定していた`class 属性`の名称を変更(タイムラインと合わせるため)