### PR TITLE
投稿詳細ページのレスポンシブスタイルを修正

### DIFF
--- a/app/views/users/_posts_paginate.html.erb
+++ b/app/views/users/_posts_paginate.html.erb
@@ -1,5 +1,11 @@
-<div class="col-4 p-1">
-  <%= link_to post do %>
-    <%= image_tag post.photos.first.image.url, class: "img-fluid fadein-image", width: "1080px", height: "1080px" %>
+<% if posts.any? %>
+  <% posts.each do |post| %>
+    <div class="col-4 p-1">
+      <%= link_to post do %>
+        <%= image_tag post.photos.first.image.url, class: "img-fluid fadein-image", width: "1080px", height: "1080px" %>
+      <% end %>
+    </div>
   <% end %>
-</div>
+<% else %>
+  <p class="my-5 mx-auto">投稿がありません</p>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,7 +77,7 @@
         </small>
       </a>
     </div>
-    <div class="tab-content pt-3" id="nav-tabContent">
+    <div class="tab-content pt-3 pb-sm-5" id="nav-tabContent">
       <div class="tab-pane fade show active" id="list-posts" role="tabpanel" area-labelledby="list-posts-list">
         <div class="d-flex flex-wrap" id="user-posts">
           <%= render partial: "posts_paginate", locals: { posts: @posts } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -80,7 +80,7 @@
     <div class="tab-content pt-3" id="nav-tabContent">
       <div class="tab-pane fade show active" id="list-posts" role="tabpanel" area-labelledby="list-posts-list">
         <div class="d-flex flex-wrap" id="user-posts">
-          <%= render partial: "posts_paginate", collection: @posts, as: "post" %>
+          <%= render partial: "posts_paginate", locals: { posts: @posts } %>
         </div>
         <div id="user-posts-paginate">
           <%= paginate @posts, param_name: "post_page", remote: true, params: { data: "user" } %>
@@ -88,7 +88,7 @@
       </div>
       <div class="tab-pane fade" id="list-liked" role="tabpanel" area-labelledby="list-liked-list">
         <div class="d-flex flex-wrap" id="posts-liked">
-          <%= render partial: "posts_paginate", collection: @likes, as: "post" %>
+          <%= render partial: "posts_paginate", locals: { posts: @likes } %>
         </div>
         <div id="posts-liked-paginate">
           <%= paginate @likes, param_name: "like_page", remote: true, params: { data: "like" } %>
@@ -97,7 +97,7 @@
       <% if current_user.id == @user.id %>
         <div class="tab-pane fade" id="list-marked" role="tabpanel" area-labelledby="list-marked-list">
           <div class="d-flex flex-wrap" id="posts-marked">
-            <%= render partial: "posts_paginate", collection: @marks, as: "post" %>
+            <%= render partial: "posts_paginate", locals: { posts: @marks } %>
           </div>
           <div id="posts-marked-paginate">
             <%= paginate @marks, param_name: "mark_page", remote: true, params: { data: "mark" } %>
@@ -106,7 +106,11 @@
       <% elsif %>
         <div class="tab-pane fade" id="list-item" role="tabpanel" area-labelledby="list-item-list">
           <div class="d-flex flex-wrap my-items" id="posts-item">
-            <%= render @items %>
+            <% if @items.any? %>
+              <%= render @items %>
+            <% else %>
+              <p class="my-5 mx-auto">アイテムがありません</p>
+            <% end %>
           </div>
           <div id="posts-item-paginate">
             <%= paginate @items, param_name: "item_page", remote: true, params: { data: "item" } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,7 @@
   </div>
 </div>
 <div class="row">
-  <div class="col-12 col-md-6 d-flex flex-column h-100">
+  <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="row m-0">
       <div class="col-3 col-md-4 avatar-container p-0 mb-4">
         <%= image_tag @user.avatar.url, class: "rounded-circle user-avatar bg-light" %>
@@ -55,7 +55,7 @@
       </div>
     <% end %>
   </div>
-  <div class="col-12 col-md-6 d-flex flex-column h-100">
+  <div class="col-12 col-xl-6 d-flex flex-column h-100">
     <div class="list-group list-group-horizontal w-100" id="list-tab" role="tablist">
       <a class="list-group-item flex-fill list-group-item-action active text-reset rounded-0 px-0" id="list-posts-list" data-toggle="list" href="#list-posts" role="tab" aria-controls="posts" data-tab="list-posts">
         <small class="d-flex justify-content-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,7 +42,7 @@
       <%= @user.name %>
     </div>
     <div class="border-bottom user-info mb-3">
-      <%= @user.address %>
+      <%= @user.address_i18n %>
     </div>
     <% if @user.favorite_items? %>
       <div class="border-bottom user-info mb-3">

--- a/app/views/users/show.js.erb
+++ b/app/views/users/show.js.erb
@@ -1,25 +1,25 @@
 switch('<%= params[:data] %>'){
   case 'user':
     document.getElementById('user-posts').textContent = '';
-    document.getElementById('user-posts').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @posts, as: "post") %>');
+    document.getElementById('user-posts').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", locals: { posts: @posts }) %>');
     document.getElementById('user-posts-paginate').textContent = '';
     document.getElementById('user-posts-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @posts, param_name: "post_page", remote: true, params: { data: "user" }) %>');
     break;
   case 'like':
     document.getElementById('posts-liked').textContent = '';
-    document.getElementById('posts-liked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @likes, as: "post") %>');
+    document.getElementById('posts-liked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", locals: { posts: @likes }) %>');
     document.getElementById('posts-liked-paginate').textContent = '';
     document.getElementById('posts-liked-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @likes, param_name: "like_page", remote: true, params: { data: "like" }) %>');
     break;
   case 'mark':
     document.getElementById('posts-marked').textContent = '';
-    document.getElementById('posts-marked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", collection: @marks, as: "post") %>');
+    document.getElementById('posts-marked').insertAdjacentHTML('afterbegin', '<%= j render(partial: "posts_paginate", locals: { posts: @marks }) %>');
     document.getElementById('posts-marked-paginate').textContent = '';
     document.getElementById('posts-marked-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @marks, param_name: "mark_page", remote: true, params: { data: "mark" }) %>');
     break;
   case 'item':
     document.getElementById('posts-item').textContent = '';
-    document.getElementById('posts-item').insertAdjacentHTML('afterbegin', '<%= j render(partial: "item", collection: @items) %>');
+    document.getElementById('posts-item').insertAdjacentHTML('afterbegin', '<%= j render(@items) %>');
     document.getElementById('posts-item-paginate').textContent = '';
     document.getElementById('posts-item-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @items, param_name: "item_page", remote: true, params: { data: "item" }) %>');
     break;


### PR DESCRIPTION
close #131
  
## 実装内容
- ユーザー詳細ページのブレークポイントを`md`から`xl`に修正
- 投稿、いいね一覧、マーク一覧、アイテムのタブ表示で表示するコンテンツがない場合はその旨を表示するように設定
  - レンダリングする際にパーシャルにコレクションを渡す形からローカル変数を渡す形に修正
- ユーザーのお住まいを日本語で表示
  
## 動作確認
- [x] 開発環境での動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行