### PR TITLE
他ユーザーのアイテムページへのアクセスを制限

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,10 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: :destroy
+
   PER_PAGE = 20
   def index
-    user = User.find(params[:user_id])
-    @items = user.items.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    @user = User.find(params[:user_id])
+    @items = @user.items.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @page = params[:page]
   end
 
@@ -17,12 +19,15 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = current_user.items.find(params[:id])
     @item.destroy!
     flash.now[:alert] = "#{@item.name} を削除しました"
   end
 
   private
+
+  def set_item
+    @item = current_user.items.find(params[:id])
+  end
 
   def registered_item?
     return unless current_user.items.find_by(name: params[:name])

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,5 @@
 module ItemsHelper
+  def item_page_title(user)
+    current_user.id == user.id ? { title: 'My Item', sub_title: 'マイアイテム' } : { title: 'User Item', sub_title: 'ユーザーアイテム' }
+  end
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,4 +1,4 @@
-<li class="col-12 border-bottom px-1" id="my-item-<%= item.id %>" >
+<li class="col-12 border-bottom px-3 py-2" id="my-item-<%= item.id %>" >
   <div class="row bg-white w-100 m-0 py-1">
     <div class="col-3 align-self-center bg-white p-0">
       <div class="item-container mx-auto">

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -10,7 +10,7 @@
         <p class="d-flex align-items-center pl-3 my-auto"><%= item.name %></p>
         <p class="d-flex align-items-center text-muted pl-3 my-auto"><%= item.genre %></p>
       </div>
-      <% if controller_name == 'items' %>
+      <% if controller_name == 'items' && current_user.id == user.id %>
         <div class="dropdown px-3 ml-auto">
           <button class="btn btn-link btn-sm text-reset p-0" type="button" id="my-item-menu-<%= item.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fas fa-ellipsis-h"></i>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,35 +1,37 @@
 <div class="d-flex justify-content-center pt-3">
   <div class="d-inline-flex flex-column headline pb-4">
-    <h2 class="m-0">My Item</h2>
-    <p class="text-center text-muted">マイアイテム</p>
+    <h2 class="m-0"><%= item_page_title(@user)[:title] %></h2>
+    <p class="text-center text-muted"><%= item_page_title(@user)[:sub_title] %></p>
   </div>
 </div>
-<div class="search-item-group mb-3">
-  <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#search-item" aria-expanded="false" aria-controls="search-item" id="collapse-search-item">
-    アイテムを追加する<i class="fas fa-plus ml-3"></i>
-  </button>
-  <div class="collapse item-collapse py-4 mb-4" id="search-item">
-    <%= form_with url: search_items_path, method: :get, local: true do |form| %>
-    <div class="input-group px-3">
-      <%= form.text_field :keyword, class: "form-control", placeholder: "追加したいアイテムを検索", value: params[:keyword], required: true %>
-      <div class="input-group-append">
-        <%= button_tag type: :submit, class: "btn btn-info" do %>
-          <i class="fas fa-search"></i>
-        <% end %>
+<% if current_user.id == @user.id %>
+  <div class="search-item-group mb-3">
+    <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#search-item" aria-expanded="false" aria-controls="search-item" id="collapse-search-item">
+      アイテムを追加する<i class="fas fa-plus ml-3"></i>
+    </button>
+    <div class="collapse item-collapse py-4 mb-4" id="search-item">
+      <%= form_with url: search_items_path, method: :get, local: true do |form| %>
+      <div class="input-group px-3">
+        <%= form.text_field :keyword, class: "form-control", placeholder: "追加したいアイテムを検索", value: params[:keyword], required: true %>
+        <div class="input-group-append">
+          <%= button_tag type: :submit, class: "btn btn-info" do %>
+            <i class="fas fa-search"></i>
+          <% end %>
+        </div>
       </div>
+    <% end %>
     </div>
-  <% end %>
   </div>
-</div>
+<% end %>
 <% if @items.present? %>
   <div id="jscroll-item">
     <ul class="row bg-white py-3 px-0 mb-0 my-items">
-      <%= render @items %>
+      <%= render @items, user: @user %>
     </ul>
     <div id="my-item-paginate">
       <%= paginate @items, remote: true %>
     </div>
   </div>
-<% elsif %>
+<% else %>
   <h3 class="d-flex justify-content-center pt-5">アイテムがまだありません</h3>
 <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <% if @items.present? %>
   <div id="jscroll-item">
-    <ul class="row bg-white px-0 mb-0 my-items">
+    <ul class="row bg-white px-0 my-items">
       <%= render @items, user: @user %>
     </ul>
     <div id="my-item-paginate">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 <% if @items.present? %>
   <div id="jscroll-item">
-    <ul class="row bg-white py-3 px-0 mb-0 my-items">
+    <ul class="row bg-white px-0 mb-0 my-items">
       <%= render @items, user: @user %>
     </ul>
     <div id="my-item-paginate">

--- a/app/views/items/index.js.erb
+++ b/app/views/items/index.js.erb
@@ -1,5 +1,5 @@
 document.getElementsByClassName('my-items')[0].textContent = '';
-document.getElementsByClassName('my-items')[0].insertAdjacentHTML('afterbegin', '<%= j render(@items) %>');
+document.getElementsByClassName('my-items')[0].insertAdjacentHTML('afterbegin', '<%= j render(@items, user: @user) %>');
 document.getElementById('my-item-paginate').textContent = '';
 document.getElementById('my-item-paginate').insertAdjacentHTML('afterbegin', '<%= j (paginate @items, remote: true) %>');
 history.replaceState( "", "" ,"?page=<%= @page %>");

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,6 +1,6 @@
 <%= paginator.render do %>
   <nav>
-    <ul class="pagination pagination-sm my-2" id="custom-pagination">
+    <ul class="pagination pagination-sm mb-5" id="custom-pagination">
       <%= first_page_tag unless current_page.first? %>
       <%= prev_page_tag unless current_page.first? %>
       <% each_page do |page| %>

--- a/app/views/search_items/index.html.erb
+++ b/app/views/search_items/index.html.erb
@@ -14,8 +14,8 @@
     </div>
   </div>
 <% end %>
-<div id="search_item_list">
+<div id="search-item-list">
   <% if @search_items.present? %>
-    <%= render "search_item", @search_items %>
+    <%= render "search_item", search_items: @search_items %>
   <% end %>
 </div>

--- a/app/views/search_items/index.js.erb
+++ b/app/views/search_items/index.js.erb
@@ -1,1 +1,1 @@
-document.getElementById('search_item_list').innerHTML = '<%= j render("search_items/search_items", search_items: @search_items) %>'
+document.getElementById('search-item-list').innerHTML = '<%= j render("search_item", search_items: @search_items) %>'

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -107,7 +107,7 @@
         <div class="tab-pane fade" id="list-item" role="tabpanel" area-labelledby="list-item-list">
           <div class="d-flex flex-wrap my-items" id="posts-item">
             <% if @items.any? %>
-              <%= render @items %>
+              <%= render @items, user: @user %>
             <% else %>
               <p class="my-5 mx-auto">アイテムがありません</p>
             <% end %>


### PR DESCRIPTION
close #133 
  
## 実装内容
- ログインユーザー以外のマイアイテムページへアクセスした際に`マイアイテム検索フォーム`と`ドロップダウンメニュー`を非表示にするように設定
- Ajax でのマイアイテム追加機能を修正
- `各アイテム`と`ページネション`の余白を修正
- アイテムページのタイトルをログインユーザーとそうでない場合で表示を変えるために`ヘルパーメソッド`を作成
  - `items_helper.rb`へユーザー情報を渡すためにコントローラでインスタンス変数を定義
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] ローカルでの動作確認