### PR TITLE
Post モデルのテストを修正 

### DIFF
--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -7,9 +7,10 @@ class PostForm
   validates :content, presence: true, length: { maximum: 2000 }
   # Photo モデルのバリデーション
   validates :image, presence: true, on: :create
+  validates :image, image_length: true
 
-  validates :tag_ids, presence: true, length: { maximum: 2 }
-  validates :category_ids, presence: true, length: { maximum: 2 }
+  validates :tag_ids, presence: true, length: { maximum: 2 }, custom_numericality: { allow_blank: true }
+  validates :category_ids, presence: true, length: { maximum: 2 }, custom_numericality: { allow_blank: true }
 
   def save
     return false if invalid?

--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -15,7 +15,7 @@ class PostForm
     return false if invalid?
 
     ActiveRecord::Base.transaction do
-      if @post.persisted?
+      if post.persisted?
         post_update
       else
         post_create
@@ -36,14 +36,14 @@ class PostForm
         post.photos.build(image: img).save!
       end
     end
-    raise ActiveRecord::Rollback unless @post.photos.any?
+    raise ActiveRecord::Rollback unless post.photos.any?
 
-    @post.update!(content: content, tag_ids: tag_ids, category_ids: category_ids)
+    post.update!(content: content, tag_ids: tag_ids, category_ids: category_ids)
   end
 
   def post_create
     post = Post.new(content: content, user_id: user_id, tag_ids: tag_ids, category_ids: category_ids)
-    return if image.blank?
+    return false if image.blank?
 
     image.each do |img|
       post.photos.build(image: img).save!

--- a/app/validators/custom_numericality_validator.rb
+++ b/app/validators/custom_numericality_validator.rb
@@ -1,0 +1,9 @@
+class CustomNumericalityValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    value.each do |v|
+      if (attribute == :tag_ids && v.to_i > 12) || (attribute == :category_ids && v.to_i > 6)
+        record.errors.add attribute, (options[:message] || '入力された値は存在しません')
+      end
+    end
+  end
+end

--- a/app/validators/image_length_validator.rb
+++ b/app/validators/image_length_validator.rb
@@ -1,0 +1,5 @@
+class ImageLengthValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add attribute, (options[:message] || 'は最大6枚まで選択できます') if value.length > 6
+  end
+end

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -18,7 +18,7 @@
     <i class="fas fa-tag tag-color"></i>
     <%= form.label :tag_ids, "タグ", class: "font-weight-bold" %>
     <ul class="row px-3">
-      <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
+      <%= form.collection_check_boxes :tag_ids, Tag.all.order(id: :asc), :id, :name, include_hidden: false do |form| %>
         <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
           <label class="border rounded-pill w-100">
             <%= form.check_box class: "tags-check-box checkbox-visibility" %>
@@ -36,7 +36,7 @@
     <i class="fas fa-folder category-color"></i>
     <%= form.label :category_ids, "カテゴリー", class: "font-weight-bold" %>
     <ul class="row px-3">
-      <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
+      <%= form.collection_check_boxes :category_ids, Category.all.order(id: :asc), :id, :name, include_hidden: false do |form| %>
         <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
           <label class="border rounded-pill w-100">
             <%= form.check_box class: "categories-check-box checkbox-visibility" %>

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -18,7 +18,7 @@
     <i class="fas fa-tag tag-color"></i>
     <%= form.label :tag_ids, "タグ", class: "font-weight-bold" %>
     <ul class="row px-3">
-      <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |form| %>
+      <%= form.collection_check_boxes :tag_ids, Tag.all.order(id: :asc), :id, :name, include_hidden: false do |form| %>
         <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
           <label class="border rounded-pill w-100">
             <%= form.check_box class: "checkbox-visibility" %>
@@ -36,7 +36,7 @@
     <i class="fas fa-folder category-color"></i>
     <%= form.label :category_ids, "カテゴリー", class: "font-weight-bold" %>
     <ul class="row px-3">
-      <%= form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |form| %>
+      <%= form.collection_check_boxes :category_ids, Category.all.order(id: :asc), :id, :name, include_hidden: false do |form| %>
         <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
           <label class="border rounded-pill w-100">
             <%= form.check_box class: "checkbox-visibility" %>

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :category do
-    name { 'MyString' }
+    sequence(:name) { |n| "カテゴリ#{n}" }
   end
 end

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :photo do
-    image { 'MyString' }
-    post { nil }
+    image { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg')) }
+    post
   end
 end

--- a/spec/factories/photos.rb
+++ b/spec/factories/photos.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :photo do
+    sequence(:id) { |n| n }
     image { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg')) }
     post
   end

--- a/spec/factories/post_categories.rb
+++ b/spec/factories/post_categories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :post_category do
-    post { nil }
-    category { nil }
+    post
+    category
   end
 end

--- a/spec/factories/post_forms.rb
+++ b/spec/factories/post_forms.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :post_form do
+    post { Post.new }
+    content { Faker::Lorem.paragraph }
+    image { [Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg'))] }
+    tag_ids { [1, 2] }
+    category_ids { [1, 2] }
+  end
+end

--- a/spec/factories/post_tags.rb
+++ b/spec/factories/post_tags.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :post_tag do
-    post { nil }
-    tag { nil }
+    post
+    tag
   end
 end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,8 +1,13 @@
 FactoryBot.define do
   factory :post do
     content { Faker::Lorem.paragraph }
-    likes_count { rand(0..100) }
-    marks_count { rand(0..100) }
+    likes_count { nil }
+    marks_count { nil }
     user
+    after(:create) do |post|
+      create(:photo, post: post)
+      create(:post_tag, post: post)
+      create(:post_category, post: post)
+    end
   end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :tag do
-    name { 'MyString' }
+    sequence(:name) { |n| "タグ#{n}" }
   end
 end

--- a/spec/forms/post_form_spec.rb
+++ b/spec/forms/post_form_spec.rb
@@ -27,11 +27,35 @@ RSpec.describe PostForm, type: :model do
       end
     end
 
+    context 'tag_ids が空のとき' do
+      let(:post_form) { build(:post_form, tag_ids: '') }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:tag_ids]).to include 'を入力してください'
+      end
+    end
+
     context 'tag_ids が3つ以上のとき' do
       let(:post_form) { build(:post_form, tag_ids: [1, 2, 3]) }
       it 'エラーが発生すること' do
         expect(subject).to eq false
         expect(post_form.errors.messages[:tag_ids]).to include 'は2文字以内で入力してください'
+      end
+    end
+
+    context 'tag_ids の値が12以上のとき' do
+      let(:post_form) { build(:post_form, tag_ids: [13]) }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:tag_ids]).to include '入力された値は存在しません'
+      end
+    end
+
+    context 'categoryr_ids が空のとき' do
+      let(:post_form) { build(:post_form, category_ids: '') }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:category_ids]).to include 'を入力してください'
       end
     end
 
@@ -43,11 +67,32 @@ RSpec.describe PostForm, type: :model do
       end
     end
 
+    context 'categoryr_ids の値が6以上のとき' do
+      let(:post_form) { build(:post_form, category_ids: [7]) }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:category_ids]).to include '入力された値は存在しません'
+      end
+    end
+
     context 'image が空のとき' do
       let(:post_form) { build(:post_form, image: '') }
       it 'エラーが発生する' do
         expect(post_form.valid?(:create)).to eq false
         expect(post_form.errors.messages[:image]).to include 'を入力してください'
+      end
+    end
+
+    context 'image が6枚以上のとき' do
+      before do
+        @images = []
+        7.times { @images << Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg')) }
+      end
+
+      let(:post_form) { build(:post_form, image: @images) }
+      it 'エラーが発生する' do
+        expect(post_form.valid?(:create)).to eq false
+        expect(post_form.errors.messages[:image]).to include 'は最大6枚まで選択できます'
       end
     end
   end

--- a/spec/forms/post_form_spec.rb
+++ b/spec/forms/post_form_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe PostForm, type: :model do
+  describe 'バリデーション' do
+    subject { post_form.valid? }
+
+    context 'データが条件を満たすとき' do
+      let(:post_form) { build(:post_form) }
+      it '保存できること' do
+        expect(subject).to eq true
+      end
+    end
+
+    context 'content が空のとき' do
+      let(:post_form) { build(:post_form, content: '') }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:content]).to include 'を入力してください'
+      end
+    end
+
+    context 'content が 2001 文字以上のとき' do
+      let(:post_form) { build(:post_form, content: 'a' * 2001) }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:content]).to include 'は2000文字以内で入力してください'
+      end
+    end
+
+    context 'tag_ids が3つ以上のとき' do
+      let(:post_form) { build(:post_form, tag_ids: [1, 2, 3]) }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:tag_ids]).to include 'は2文字以内で入力してください'
+      end
+    end
+
+    context 'categoryr_ids が3つ以上のとき' do
+      let(:post_form) { build(:post_form, category_ids: [1, 2, 3]) }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(post_form.errors.messages[:category_ids]).to include 'は2文字以内で入力してください'
+      end
+    end
+
+    context 'image が空のとき' do
+      let(:post_form) { build(:post_form, image: '') }
+      it 'エラーが発生する' do
+        expect(post_form.valid?(:create)).to eq false
+        expect(post_form.errors.messages[:image]).to include 'を入力してください'
+      end
+    end
+  end
+
+  describe '#save' do
+    subject { post_form.save }
+
+    let(:user) { create(:user) }
+    before do
+      create(:tag, id: 1)
+      create(:tag, id: 2)
+      create(:category, id: 1)
+      create(:category, id: 2)
+    end
+
+    describe '#post_update' do
+      let(:post) { create(:post, user: user) }
+
+      context 'データが条件を満たすとき' do
+        let(:post_form) { build(:post_form, post: post) }
+        it '更新できること' do
+          expect(subject).to eq true
+        end
+      end
+
+      context '画像が1つも選択されていない場合' do
+        let(:post_form) { build(:post_form, post: post, delete_ids: [2], image: '') }
+        it '更新されないこと' do
+          expect { subject }.to change { post.photos.count }.by(0)
+        end
+      end
+    end
+
+    describe '#post_create' do
+      context 'データが条件を満たすとき' do
+        let(:post_form) { build(:post_form, user_id: user.id) }
+        it '新規作成できること' do
+          expect { subject }.to change { user.posts.count }.by(1)
+        end
+      end
+
+      context '画像が選択されていない場合' do
+        let(:post_form) { build(:post_form, user_id: user.id, image: '') }
+        it 'エラーが発生すること' do
+          expect(subject).to eq false
+        end
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,32 +1,45 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
-  describe 'バリデーション' do
-    subject { post.valid? }
+  describe 'メソッド' do
+    let(:user) { build(:user) }
+    let(:post1) { build(:post) }
+    let(:post2) { build(:post) }
+    describe '#liked_by?' do
+      before do
+        create(:like, user: user, post: post1)
+        create_list(:like, 2)
+      end
 
-    context 'データが条件を満たすとき' do
-      let(:post) { build(:post) }
-      it '保存できること' do
-        expect(subject).to eq true
+      context 'いいねした投稿の場合' do
+        it 'true となること' do
+          expect(post1.liked_by?(user)).to eq true
+        end
+      end
+
+      context 'いいねした投稿では無い場合' do
+        it 'false となること' do
+          expect(post2.liked_by?(user)).to eq false
+        end
       end
     end
 
-    # content のバリデーションテスト
-    context 'content が空のとき' do
-      let(:post) { build(:post, content: '') }
-      it 'エラーが発生すること' do
-        expect(subject).to eq false
-        expect(post.errors.messages[:content]).to include 'を入力してください'
-        # expect { subject }.to raise_error 'バリデーションに失敗しました: 投稿内容を入力してください'
+    describe '#marked_by?' do
+      before do
+        create(:mark, user: user, post: post1)
+        create_list(:mark, 2)
       end
-    end
 
-    context 'content が 2001 文字以上のとき' do
-      let(:post) { build(:post, content: 'a' * 2001) }
-      it 'エラーが発生すること' do
-        expect(subject).to eq false
-        expect(post.errors.messages[:content]).to include 'は2000文字以内で入力してください'
-        # expect { subject }.to raise_error 'バリデーションに失敗しました: 投稿内容は2000文字以内で入力してください'
+      context 'マークした投稿の場合' do
+        it 'true となること' do
+          expect(post1.marked_by?(user)).to eq true
+        end
+      end
+
+      context 'マークした投稿では無い場合' do
+        it 'false となること' do
+          expect(post2.marked_by?(user)).to eq false
+        end
       end
     end
   end


### PR DESCRIPTION
close #137
  
## 実装内容
- `Post モデル`の Factory (初期データ) 作成時に関連するモデル`Photo`,`Tag`,`Category`のデータを同時に作成
- PostForm(フォームオブジェクト)の save メソッドでの`@post`の変数名を`post`に修正(PostForm.new の際に変数として渡しているため)
- `PostForm`の Factory (初期データ) を作成
- 投稿作成・更新時のバリデーションテストを`PostForm(フォームオブジェクト)`に作成
- `PostForm(フォームオブジェクト)`のメソッドのテストを作成
- `Post モデル`のメソッドのテストを作成
- 投稿モーダルのタグ・カテゴリ選択表示を `id 順` で表示するように設定
- `image`,`tag_ids`,`category_ids`のカスタムバリデーションを作成
  - image は最大で`6枚`までとする
  - tag_ids は値を`12以下`とする
  - category_ids は値を`12以下`とする
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [ ] `bundle exec rspec spec/forms/post_form_spec.rb spec/models/post_spec.rb`で投稿関連のテストを実行