### PR TITLE
add: Photo モデルのモデルスペックを作成

### DIFF
--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -1,5 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe Photo, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    subject { photo.valid? }
+
+    context 'データが条件を満たすとき' do
+      let(:photo) { build(:photo) }
+      it '保存できること' do
+        expect(subject).to eq true
+      end
+    end
+
+    context 'image の画像サイズが 5MB 以上のとき' do
+      let(:photo) { build(:photo, image: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_size_test.jpg'))) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(photo.errors.messages[:image]).to include 'ファイルを5MBバイト以下のサイズにしてください'
+      end
+    end
+
+    context 'image の拡張子が .jpeg .jpg .png 以外のとき' do
+      let(:photo) { build(:photo, image: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/rspec_extension_test.tiff'))) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(photo.errors.messages[:image]).to include '"tiff"ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: jpg, jpeg, png'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 実装内容
- `image`のバリデーションテスト
  - ~~空文字の場合、エラーが発生すること~~ (フォームオブジェクトで投稿作成時にバリデーションテストを作成済)
  - 拡張子が `.jpg`, `.jpeg`, `.png`以外の場合、エラーが発生する事
  - 画像サイズが 5MB 以上の場合、エラーが発生する事
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/models/photo_spec.rb`でテストが通ることを確認