### PR TITLE
PostTag モデルのテスト(モデルスペック)

### DIFF
--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,5 +1,8 @@
 class PostTag < ApplicationRecord
   belongs_to :post
   belongs_to :tag
-  validates :post_id, uniqueness: { scope: :tag_id }
+  validates :post_id, uniqueness: {
+    scope: :tag_id,
+    message: 'ではすでにこのタグが選択されています'
+  }
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,9 @@ ja:
         name: カテゴリ
         created_at: 作成日
         updated_at: 更新日
+      post_tag:
+        post: 投稿
+        tag: タグ
       comment:
         content: コメント内容
         user: ユーザー

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Post, type: :model do
       create_list(:like, 2, post: post)
       create_list(:mark, 2, post: post)
       create_list(:photo, 2, post: post)
+      create(:post_tag, post: post)
     end
 
     it 'その投稿のいいねも削除される' do
@@ -66,6 +67,10 @@ RSpec.describe Post, type: :model do
 
     it 'その投稿の画像も削除される' do
       expect { subject }.to change { post.photos.count }.by(-3)
+    end
+
+    it 'その投稿のタグも削除される' do
+      expect { subject }.to change { post.post_tags.count }.by(-2)
     end
   end
 end

--- a/spec/models/post_tag_spec.rb
+++ b/spec/models/post_tag_spec.rb
@@ -1,5 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe PostTag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    subject { post_tag.valid? }
+
+    context 'データが条件を満たすとき' do
+      let(:post_tag) { build(:post_tag) }
+      it '保存できること' do
+        expect(subject).to eq true
+      end
+    end
+
+    context 'post_id が空のとき' do
+      let(:post_tag) { build(:post_tag, post_id: nil) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(post_tag.errors.messages[:post]).to include 'を入力してください'
+      end
+    end
+
+    context 'tag_id がからのとき' do
+      let(:post_tag) { build(:post_tag, tag_id: nil) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(post_tag.errors.messages[:tag]).to include 'を入力してください'
+      end
+    end
+
+    context '1つの投稿に同じタグを付けた場合' do
+      let(:post) { build(:post) }
+      let(:tag) { build(:tag) }
+      let(:post_tag) { build(:post_tag, post: post, tag: tag) }
+      before do
+        create(:post_tag, post: post, tag: tag)
+      end
+
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(post_tag.errors.messages[:post_id]).to include 'ではすでにこのタグが選択されています'
+      end
+    end
+  end
 end


### PR DESCRIPTION
close #142
  
## 実装内容
- テスト内容
  - データが条件を満たすとき、保存できること
  - `post_id`が空のとき、エラーが発生する
  - `tag_id`が空のとき、エラーが発生する
  - `post_id`と`tag_id`が一意でない場合、エラーが発生する
    - モデルでエラーメッセージを設定
  - 投稿を削除した場合、その投稿の`タグ`も削除されること(Post モデルに定義)
  
## 動作確認
- [x] `rubocop -A`を実装
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/models/post_spec.rb`を実行してテストが通るのを確認
- [x] `bundle exec rspec spec/models/post_tag_spec.rb`を実行してテストが通るのを確認