### PR TITLE
KnowHow モデルの作成

### DIFF
--- a/app/models/know_how.rb
+++ b/app/models/know_how.rb
@@ -2,4 +2,6 @@ class KnowHow < ApplicationRecord
   validates :genre, presence: true
   validates :title, presence: true
   validates :content, presence: true
+
+  enum genre: { all_rooms: 1, kitchen: 2, toilet: 3, bath: 4, washbasin: 5, balcony: 6, entrance: 7 }
 end

--- a/app/models/know_how.rb
+++ b/app/models/know_how.rb
@@ -1,0 +1,5 @@
+class KnowHow < ApplicationRecord
+  validates :genre, presence: true
+  validates :title, presence: true
+  validates :content, presence: true
+end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -86,7 +86,7 @@
         <div class="card text-center h-100">
           <%= link_to "#", class: "text-reset" do %>
             <div class="card-header p-3">
-              <h3 class="card-title">About</h3>
+              <h3 class="card-title">Know How</h3>
               <h6 class="card-subtitle">ノウハウ</h6>
             </div>
             <div class="card-body p-3">

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -64,3 +64,12 @@ ja:
         four_person_household: '4人世帯'
         five_person_household: '5人世帯'
         others_household: 'それ以外の方'
+    know_how:
+      genre:
+        all_rooms: '部屋全体'
+        kitchen: 'キッチン'
+        toilet: 'トイレ'
+        bath: 'お風呂'
+        washbasin: '洗面台'
+        balcony: 'ベランダ'
+        entrance: '玄関'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
       mark: マーク
       item: アイテム
       inquiry: お問い合わせ
+      know_how: ノウハウ
     attributes:
       post:
         content: 投稿内容
@@ -57,6 +58,10 @@ ja:
         email: メールアドレス
         content: お問い合わせ内容
         remote_ip: IPアドレス
+      know_how:
+        genre: ジャンル
+        title: タイトル
+        content: 内容
   views:
     pagination:
       first: "&laquo;"

--- a/db/migrate/20220404111648_create_know_hows.rb
+++ b/db/migrate/20220404111648_create_know_hows.rb
@@ -1,0 +1,11 @@
+class CreateKnowHows < ActiveRecord::Migration[6.1]
+  def change
+    create_table :know_hows do |t|
+      t.integer :genre, null: false, default: 0
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_12_152448) do
+ActiveRecord::Schema.define(version: 2022_04_04_111648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,14 @@ ActiveRecord::Schema.define(version: 2022_02_12_152448) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "know_hows", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "likes", force: :cascade do |t|

--- a/spec/factories/know_hows.rb
+++ b/spec/factories/know_hows.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :know_how do
+    genre { 1 }
+    title { 'MyString' }
+    content { 'MyText' }
+  end
+end

--- a/spec/models/know_how_spec.rb
+++ b/spec/models/know_how_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe KnowHow, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
close #149
  
## 実装内容
- `KnowHow`モデルを作成
  - `genre`(integer)
  - `title`(string)
  - `content`(text)
  - 全てのカラムに`空文字禁止`のバリデーションを設定
  - 全てのカラムに`NOT NULL 制約`を設定
  - `genre`カラムのデフォルト値は`0`に設定
- トップページの `About`の表示を`Know How`に修正
- `KnowHow`モデルの日本語訳を設定
- `genre`を`enum`で定義
  ```rb
  enum genre: { all_rooms: 1, kitchen: 2, toilet: 3, bath: 4, washbasin: 5, balcony: 6, entrance: 7 }
  ```
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] enum を使用してデータが作成できることを確認
- [x] `know_how.genre_i18n`で日本語表示されることを確認
- [x] コンソールからノウハウを作成して、バリデーションが効いていること、エラーメッセージが日本語で表示されていることを確認
- [x] トップページへアクセスして`About`の表示が`Know How`になっていることを確認