### PR TITLE
AdminUser モデルのテスト(モデルスペック)

### DIFF
--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :admin_user do
+    email { Faker::Internet.unique.email }
+    password { Faker::Internet.password(min_length: 8) }
   end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,5 +1,66 @@
 require 'rails_helper'
 
 RSpec.describe AdminUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    subject { admin_user.valid? }
+
+    context 'データが条件を満たすとき' do
+      let(:admin_user) { build(:admin_user) }
+      it '保存できること' do
+        expect(subject).to eq true
+      end
+    end
+
+    context 'email が空のとき' do
+      let(:admin_user) { build(:admin_user, email: '') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(admin_user.errors.messages[:email]).to include 'を入力してください'
+      end
+    end
+
+    context 'email がすでに存在するとき' do
+      before do
+        create(:admin_user, email: 'admin@example.com')
+      end
+
+      let(:admin_user) { build(:admin_user, email: 'admin@example.com') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(admin_user.errors.messages[:email]).to include 'はすでに存在します'
+      end
+    end
+
+    context 'email がアルファベット・英数字のみのとき' do
+      let(:admin_user) { build(:admin_user, email: Faker::Lorem.characters(number: 16)) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(admin_user.errors.messages[:email]).to include 'は不正な値です'
+      end
+    end
+
+    context 'password が空のとき' do
+      let(:admin_user) { build(:admin_user, password: '') }
+      it 'エラーが発生すること' do
+        expect(subject).to eq false
+        expect(admin_user.errors.messages[:password]).to include 'を入力してください'
+      end
+    end
+
+    context 'password が5文字以下のとき' do
+      let(:admin_user) { build(:admin_user, password: 'a' * 5) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(admin_user.errors.messages[:password]).to include 'は6文字以上で入力してください'
+      end
+    end
+
+    context 'password が129文字以上のとき' do
+      let(:admin_user) { build(:admin_user, password: 'a' * 129) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(admin_user.errors.messages[:password]).to include 'は128文字以内で入力してください'
+      end
+    end
+  end
 end


### PR DESCRIPTION
close #153
  
## 実装内容
- テスト内容
  - 条件を満たすとき、データが保存できること
  - `email`
    - 空のとき、エラーが発生すること
    - すでに存在するとき、エラーが発生すること
    - アルファベット・英数字のみのとき、エラーが発生すること
  - `password`
    - 空のとき、エラーが発生すること
    - 5文字以下のとき、エラーが発生すること
    - 129文字以上のとき、エラーが発生すること
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/models/admin_user_spec.rb`を実行してテストが通ることを確認