### PR TITLE
Inquiry モデルのテスト(モデルスペック)

### DIFF
--- a/spec/factories/inquiries.rb
+++ b/spec/factories/inquiries.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :inquiry do
-    name { 'MyString' }
-    name_kana { 'MyString' }
-    email { 'MyString' }
-    content { 'MyText' }
-    remote_ip { '' }
+    name { Faker::Name.name }
+    name_kana { 'フリガナ' }
+    email { Faker::Internet.unique.email }
+    content { Faker::Lorem.paragraph }
+    remote_ip { Faker::Number.number }
   end
 end

--- a/spec/models/inquiry_spec.rb
+++ b/spec/models/inquiry_spec.rb
@@ -1,5 +1,102 @@
 require 'rails_helper'
 
 RSpec.describe Inquiry, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    subject { inquiry.valid? }
+
+    context 'データが条件を満たすとき' do
+      let(:inquiry) { build(:inquiry) }
+      it '保存できること' do
+        expect(subject).to eq true
+      end
+    end
+
+    context 'name が空の時' do
+      let(:inquiry) { build(:inquiry, name: '') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:name]).to include 'を入力してください'
+      end
+    end
+
+    context 'name が49文字以上のとき' do
+      let(:inquiry) { build(:inquiry, name: 'a' * 49) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:name]).to include 'は48文字以内で入力してください'
+      end
+    end
+
+    context 'name_kana が空のとき' do
+      let(:inquiry) { build(:inquiry, name_kana: '') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:name_kana]).to include 'を入力してください'
+      end
+    end
+
+    context 'name_kana が全角カタカナ以外のとき' do
+      let(:inquiry) { build(:inquiry, name_kana: 'ﾌﾘｶﾞﾅ') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:name_kana]).to include 'は全角カタカナで入力してください'
+      end
+    end
+
+    context 'name_kana が49文字以上のとき' do
+      let(:inquiry) { build(:inquiry, name_kana: 'a' * 49) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:name_kana]).to include 'は48文字以内で入力してください'
+      end
+    end
+
+    context 'email が空のとき' do
+      let(:inquiry) { build(:inquiry, email: '') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:email]).to include 'を入力してください'
+      end
+    end
+
+    context 'email がアルファベット・英数字のみのとき' do
+      let(:inquiry) { build(:inquiry, email: Faker::Lorem.characters(number: 16)) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:email]).to include 'は不正な値です'
+      end
+    end
+
+    context 'email が257文字以上のとき' do
+      let(:inquiry) { build(:inquiry, email: Faker::Lorem.characters(number: 257)) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:email]).to include 'は256文字以内で入力してください'
+      end
+    end
+
+    context 'content が空のとき' do
+      let(:inquiry) { build(:inquiry, content: '') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:content]).to include 'を入力してください'
+      end
+    end
+
+    context 'content が2001文字以上のとき' do
+      let(:inquiry) { build(:inquiry, content: 'a' * 2001) }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:content]).to include 'は2000文字以内で入力してください'
+      end
+    end
+
+    context 'remote_ip が空のとき' do
+      let(:inquiry) { build(:inquiry, remote_ip: '') }
+      it 'エラーが発生する' do
+        expect(subject).to eq false
+        expect(inquiry.errors.messages[:remote_ip]).to include 'を入力してください'
+      end
+    end
+  end
 end


### PR DESCRIPTION
close #155
  
## 実装内容
- Factory で`Inquiry`モデルの初期データを作成
- テスト内容
  - `name`
    - 空のとき、エラーが発生すること
    - 49文字以上のとき、エラーが発生すること
  - `name_kana`
    - 空のとき、エラーが発生すること
    - 全角カタカナでないとき、エラーが発生すること
    - 49文字以上のとき、エラーが発生すること
  - `email`
    - 空のとき、エラーが発生すること
    - アルファベット・英数字のみのとき、エラーが発生すること
    - 257文字以上のとき、エラーが発生すること
  - `content`
    - 空のとき、エラーが発生すること
    - 2001文字以上のとき、エラーが発生すること
  - `remote_ip`
    - 空のとき、エラーが発生すること
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/models/inquiry_spec.rb`を実行してテストが通ることを確認