### PR TITLE
ユーザー新規作成・編集のシステムスペックを追加

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -12,3 +12,7 @@ p img {
   height: 200px;
   border: 1px solid #ced4da;
 }
+
+.avatar-image-field {
+  display: none;
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,7 +11,7 @@
     <div class="avatar-container">
       <%= f.label :avatar, class: "avatar-label rounded-circle" do %>
         <%= image_tag @user.avatar.url, class: "rounded-circle avatar-preview bg-light", id: "current-avatar-image" %>
-        <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;' %>
+        <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif' %>
         <%= f.hidden_field :avatar_cache %>
       <% end %>
       <% if @user.avatar? %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -30,19 +30,26 @@
   <div class="form-group">
     <span class="required"><%= t('devise.shared.required') %></span>
     <%= f.label :email %>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', pattern: "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+$" %>
   </div>
 
   <div class="form-group">
     <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
+    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control', pattern: "^([a-zA-Z0-9]{6,})$" %>
 
-    <small class="form-text text-muted"><%= t('.leave_blank_if_you_don_t_want_to_change_it') %></small>
+    <small class="form-text text-muted">
+      <%= t('.leave_blank_if_you_don_t_want_to_change_it') %>
+      <%= t('devise.shared.minimum_password_length', count: "半角英数字#{@minimum_password_length}") %>
+    </small>
   </div>
 
   <div class="form-group">
     <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'  %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control', pattern: "^([a-zA-Z0-9]{6,})$" %>
+
+    <% if @minimum_password_length %>
+      <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: "半角英数字#{@minimum_password_length}") %></small>
+    <% end %>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,7 +10,7 @@
   <div class="form-group">
     <div class="avatar-container">
       <%= f.label :avatar, class: "avatar-label rounded-circle" do %>
-        <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif', style: 'display:none;'%>
+        <%= f.file_field :avatar, class: 'avatar-image-field', accept: 'image/png,image/jpeg,image/gif'%>
         <%= f.hidden_field :avatar_cache %>
       <% end %>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -35,13 +35,18 @@
     <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', pattern: "^([a-zA-Z0-9]{6,})$", required: true %>
 
     <% if @minimum_password_length %>
-      <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
+      <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: "半角英数字#{@minimum_password_length}") %></small>
     <% end %>
   </div>
 
   <div class="form-group">
+    <span class="required"><%= t('devise.shared.required') %></span>
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control', pattern: "^([a-zA-Z0-9]{6,})$", required: true %>
+
+    <% if @minimum_password_length %>
+      <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: "半角英数字#{@minimum_password_length}") %></small>
+    <% end %>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -26,13 +26,13 @@
   <div class="form-group">
     <span class="required"><%= t('devise.shared.required') %></span>
     <%= f.label :email %>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', required: true %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', pattern: "^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]+$", required: true %>
   </div>
 
   <div class="form-group">
     <span class="required"><%= t('devise.shared.required') %></span>
     <%= f.label :password %>
-    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', required: true %>
+    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', pattern: "^([a-zA-Z0-9]{6,})$", required: true %>
 
     <% if @minimum_password_length %>
       <small class="form-text text-muted"><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></small>
@@ -41,7 +41,7 @@
 
   <div class="form-group">
     <%= f.label :password_confirmation %>
-    <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control', required: true %>
+    <%= f.password_field :password_confirmation, autocomplete: 'current-password', class: 'form-control', pattern: "^([a-zA-Z0-9]{6,})$", required: true %>
   </div>
 
   <div class="form-group">

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     age { rand(1..7) }
     address { rand(1..47) }
     household { rand(1..6) }
+    favorite_items { Faker::Lorem.word }
     profile { Faker::Lorem.sentence }
     avatar { Rack::Test::UploadedFile.new(Rails.root.join('public/images/fallback/default.png')) }
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe 'ユーザー登録・編集', type: :system do
+  describe 'アカウント登録' do
+    before do
+      visit new_user_registration_path
+      fill_in 'ユーザーネーム', with: user.name
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: user.password
+      fill_in 'パスワード（確認用）', with: user.password
+      select user.age_i18n, from: '年代'
+      select user.address_i18n, from: 'お住まい'
+      select user.household_i18n, from: '家族構成'
+      check '利用規約について同意する'
+    end
+
+    context '入力情報が条件を満たすとき' do
+      let(:user) { build(:user) }
+      it '新規登録ができること' do
+        click_button '会員登録'
+        expect(page).to have_current_path posts_path
+        expect(page).to have_content 'アカウント登録が完了しました。'
+      end
+    end
+
+    context 'パスワードとパスワード(確認用)が一致しないとき' do
+      let(:user) { build(:user, password: 'password') }
+      it 'エラーが発生すること' do
+        fill_in 'パスワード（確認用）', with: 'confirm_password'
+        click_button '会員登録'
+        expect(page).to have_current_path '/users'
+        expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
+      end
+    end
+
+    context 'メールアドレスがすでに登録済みの場合' do
+      before { create(:user, email: 'test@example.com') }
+
+      let(:user) { build(:user, email: 'test@example.com') }
+      it 'エラーが発生すること' do
+        click_button '会員登録'
+        expect(page).to have_current_path '/users'
+        expect(page).to have_content 'メールアドレスはすでに存在します'
+      end
+    end
+
+    context '画像ファイルが条件を満たさないとき' do
+      let(:user) { build(:user) }
+      it 'エラーが発生すること' do
+        attach_file('user[avatar]', Rails.root.join('spec/fixtures/rspec_size_test.jpg'))
+        click_button '会員登録'
+        expect(page).to have_current_path '/users'
+        expect(page).to have_content 'プロフィール画像ファイルを5MBバイト以下のサイズにしてください'
+      end
+    end
+  end
+
+  describe 'アカウント編集' do
+    before do
+      visit new_user_session_path
+      fill_in 'メールアドレス', with: user.email
+      fill_in 'パスワード', with: user.password
+      click_button 'ログイン'
+    end
+
+    context 'アカウント編集ページに遷移したとき' do
+      let(:user) { create(:user) }
+      it '現在のユーザー情報が入力されていること' do
+        visit edit_user_registration_path
+        expect(page).to have_selector "img[src$='#{user.avatar.filename}']"
+        expect(page).to have_field 'ユーザーネーム', with: user.name
+        expect(page).to have_field 'メールアドレス', with: user.email
+        expect(page).to have_select('年代', selected: user.age_i18n)
+        expect(page).to have_select('お住まい', selected: user.address_i18n)
+        expect(page).to have_select('家族構成', selected: user.household_i18n)
+        expect(page).to have_field 'お気に入りの家具・家電', with: user.favorite_items if user.favorite_items.present?
+        expect(page).to have_field 'プロフィール', with: user.profile if user.profile.present?
+      end
+    end
+
+    context 'アカウント情報を更新したとき' do
+      let(:user) { create(:user) }
+      let(:updated_user) { build(:user) }
+      before do
+        visit edit_user_registration_path
+        attach_file('user[avatar]', Rails.root.join('spec/fixtures/test.jpg'))
+        fill_in 'ユーザーネーム', with: updated_user.name
+        fill_in '現在のパスワード', with: user.password
+        select updated_user.address_i18n, from: 'お住まい'
+        fill_in 'お気に入りの家具・家電', with: updated_user.favorite_items
+        fill_in 'プロフィール', with: updated_user.profile
+        click_on '変更する'
+      end
+
+      it 'マイページの内容が更新されること' do
+        visit user_path(user)
+        expect(page).to have_current_path user_path(user)
+        expect(page).to have_selector "img[src$='test.jpg']"
+        expect(page).to have_content updated_user.name
+        expect(page).to have_content updated_user.address_i18n
+        expect(page).to have_content updated_user.favorite_items
+        expect(page).to have_content updated_user.profile
+      end
+    end
+
+    context 'アカウント削除ボタンを押下したとき' do
+      let(:user) { create(:user) }
+      it '削除されること' do
+        visit edit_user_registration_path
+        click_on 'アカウント削除'
+        expect(page).to have_current_path root_path
+        expect(page).to have_content 'アカウントを削除しました。またのご利用をお待ちしております。'
+      end
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'ユーザー登録・編集', type: :system do
     end
   end
 
-  describe 'アカウント編集' do
+  describe 'アカウント編集・削除' do
     before do
       visit new_user_session_path
       fill_in 'メールアドレス', with: user.email
@@ -111,6 +111,19 @@ RSpec.describe 'ユーザー登録・編集', type: :system do
         expect(page).to have_current_path root_path
         expect(page).to have_content 'アカウントを削除しました。またのご利用をお待ちしております。'
       end
+    end
+  end
+
+  context 'ゲストユーザーの削除・更新をしようとした場合' do
+    before do
+      visit root_path
+      first('.guest-login').click
+    end
+
+    it 'エラーが発生すること' do
+      visit edit_user_registration_path
+      click_on 'アカウント削除'
+      expect(page).to have_content 'ゲストユーザーの削除・更新はできません'
     end
   end
 end


### PR DESCRIPTION
close #171
  
## 実装内容
- アカウント新規登録・編集時のブラウザ側でのバリデーションを追加
  - メールアドレスの形式を正規表現で設定
  - パスワードの形式を正規表現で設定
- アカウント新規登録・編集時のユーザー情報入力の注意喚起を追加
- アカウント画像追加のフィールドの非表示設定を style 属性から css で指定するように修正
  
### テスト内容
#### 新規登録
- 入力情報が正しいとき
  - 新規登録できること
  - タイムラインページへリダイレクトすること
- パスワードとパスワード(確認用)が一致しないとき
  - エラーメッセージが表示されること
  - 新規登録ページへリダイレクトすること
- メールアドレスがすでに登録済みの場合
  - エラーメッセージが表示されること
  - 新規登録ページへリダイレクトすること
- 画像ファイルが条件を満たさないとき
  - エラーメッセージが表示されること
  - 新規登録ページへリダイレクトすること
  
#### 編集
- 編集ページへ遷移したとき
  - 登録されているデータが表示されていること
- アカウント情報を更新したとき
  - マイページの内容が更新されること
  - ユーザー詳細ページにリダイレクトすること
- アカウント削除ボタンを押下したとき
  - アカウントが削除されること
  - タイムラインページへリダイレクトすること
- ゲストユーザーの編集をしようとした場合
  - エラーメッセージが表示されること
