### PR TITLE
アイテム機能のシステムスペックを追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,9 +10,9 @@ class ItemsController < ApplicationController
 
   def create
     registered_item? and return
-    @item = current_user.items.build(name: params[:name], genre: params[:genre], image: params[:image])
+    @item = current_user.items.build(item_params)
     if @item.save
-      redirect_to user_items_path, notice: "#{params[:name]} をマイアイテムに追加しました"
+      redirect_to user_items_path, notice: "#{@item.name} をマイアイテムに追加しました"
     else
       redirect_to user_items_path, alert: 'アイテムを追加することができませんでした'
     end
@@ -29,9 +29,13 @@ class ItemsController < ApplicationController
     @item = current_user.items.find(params[:id])
   end
 
-  def registered_item?
-    return unless current_user.items.find_by(name: params[:name])
+  def item_params
+    params.require(:item).permit(:name, :genre, :remote_image_url)
+  end
 
-    redirect_to user_items_path, alert: "#{params[:name]} は既に登録されています"
+  def registered_item?
+    return unless current_user.items.find_by(name: item_params[:name])
+
+    redirect_to user_items_path, alert: "#{item_params[:name]} は既に登録されています"
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   belongs_to :user
   validates :name, presence: true
   validate :unique_item?, if: -> { user_id.present? }
+  mount_uploader :image, ItemUploader
 
   def unique_item?
     user = User.find(user_id)

--- a/app/uploaders/item_uploader.rb
+++ b/app/uploaders/item_uploader.rb
@@ -1,0 +1,54 @@
+class ItemUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url(*_args)
+    #   # For Rails 3.1+ asset pipeline compatibility:
+    #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+    #
+    "/images/fallback/#{[version_name, 'no_image.png'].compact.join('_')}"
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w[jpg jpeg png]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+  # ファイルサイズのバリデーション
+  def size_range
+    0..5.megabytes
+  end
+end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -2,11 +2,7 @@
   <div class="row bg-white w-100 m-0 py-1">
     <div class="col-3 align-self-center bg-white p-0">
       <div class="item-container mx-auto">
-        <% if item.image? %>
-          <%= image_tag item.image, class: "item-image fadein-image" %>
-        <% else %>
-          <%= image_tag '/images/fallback/no_image.png', class: "item-image fadein-image" %>
-        <% end %>
+        <%= image_tag item.image.url, class: "item-image fadein-image" %>
       </div>
     </div>
     <div class="col-9 d-flex w-100 p-0">

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -5,12 +5,12 @@
         <li class="col-6 col-sm-4 col-lg-2 d-flex flex-column px-lg-1 pt-2 mb-3">
           <div class="d-flex justify-content-center">
             <div class="d-flex justify-content-center align-items-center bg-white search-item-image">
-              <%= image_tag item["mediumImageUrl"] , class: "img-fluid" %>
+              <%= image_tag item["mediumImageUrl"], class: "img-fluid" %>
             </div>
           </div>
           <h6 class="px-2 py-2"><%= item["productName"] %></h6>
           <p class="text-muted px-2"><%= item["genreName"] %></p>
-          <%= link_to "追加", user_items_path(current_user, name: item["productName"], genre: item["genreName"], image: item["mediumImageUrl"]), method: :post, type: "button", class: "btn btn-outline-info mt-auto mx-lg-2" %>
+          <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-info mt-auto mx-lg-2" %>
         </li>
       <% end %>
     <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ items = RakutenWebService::Ichiba::Product.search(keyword: 'ダイソン', hits:
 # 管理者ユーザー用メールアドレス
 admin_email = 'admin@example.com'
 
-%w[users posts photos tags categories post_tags post_categories likes marks admin_users know_hows].each do |table_name|
+%w[users posts photos tags categories post_tags post_categories likes marks admin_users know_hows items].each do |table_name|
   ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
 end
 
@@ -51,7 +51,7 @@ items.each do |item|
   Item.create!(
     name: item['productName'],
     genre: item['genreName'],
-    image: item['mediumImageUrl'],
+    remote_image_url: item['mediumImageUrl'],
     user_id: test_user.id
   )
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :item do
     name { Faker::Lorem.word }
     genre { Faker::Lorem.word }
-    image { Rails.root.join('spec/fixtures/test.jpg') }
+    image { Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test.jpg')) }
+    remote_image_url { Faker::Avatar.image }
     user
   end
 end

--- a/spec/system/items_spec.rb
+++ b/spec/system/items_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe 'アイテム機能', type: :system do
+  before do
+    visit new_user_session_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: user.password
+    click_button 'ログイン'
+    visit user_items_path(user)
+  end
+
+  describe 'アイテム追加機能' do
+    context '検索したアイテムの追加ボタンを押下したとき' do
+      let(:user) { create(:user) }
+      let(:item) { build(:item, user: user) }
+      it 'そのアイテムがマイアイテムに追加されること' do
+        visit user_items_path(user)
+        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
+        search_items_mock = class_double(RakutenWebService::Ichiba::Product)
+        allow(search_items_mock).to receive(:search)
+        allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
+        expect { search_items_mock.search }.not_to raise_error
+        expect do
+          within '.search-item-group' do
+            click_on 'アイテムを追加する'
+            fill_in 'keyword', with: 'テストアイテム'
+            find('.input-group-append button').click
+          end
+          within '#search-item-list' do
+            all('li')[0].click_on '追加'
+          end
+          expect(page).to have_content "#{user.items.first.name} をマイアイテムに追加しました"
+          expect(page).to have_selector "img[src='#{user.items.first.image.url}']"
+          expect(page).to have_content user.items.first.name
+          expect(page).to have_content user.items.first.genre
+        end.to change { user.items.count }.by(1)
+      end
+    end
+
+    context '追加ボタンを押下したアイテムが既に登録済みのとき' do
+      let(:user) { create(:user) }
+      let(:item) { create(:item, image: nil, user: user) }
+      it 'エラーが発生すること' do
+        visit user_items_path(user)
+        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => item.name, 'genreName' => item.genre }]
+        search_items_mock = class_double(RakutenWebService::Ichiba::Product)
+        allow(search_items_mock).to receive(:search)
+        allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
+        expect { search_items_mock.search }.not_to raise_error
+        expect do
+          within '.search-item-group' do
+            click_on 'アイテムを追加する'
+            fill_in 'keyword', with: 'テストアイテム'
+            find('.input-group-append button').click
+          end
+          within '#search-item-list' do
+            all('li')[0].click_on '追加'
+          end
+          expect(page).to have_content "#{user.items.first.name} は既に登録されています"
+          expect(page).to have_selector "img[src='#{user.items.first.image.url}']"
+          expect(page).to have_content user.items.first.name
+          expect(page).to have_content user.items.first.genre
+        end.to change { user.items.count }.by(0)
+      end
+    end
+
+    context 'アイテム追加の条件を満たさないとき' do
+      let(:user) { create(:user) }
+      let(:item) { build(:item, name: nil, user: user) }
+      it 'エラーが発生すること' do
+        visit user_items_path(user)
+        product = [{ 'affiliateUrl' => Faker::Internet.url, 'mediumImageUrl' => item.remote_image_url, 'productName' => '', 'genreName' => item.genre }]
+        search_items_mock = class_double(RakutenWebService::Ichiba::Product)
+        allow(search_items_mock).to receive(:search)
+        allow(RakutenWebService::Ichiba::Product).to receive(:search).and_return(product)
+        expect { search_items_mock.search }.not_to raise_error
+        expect do
+          within '.search-item-group' do
+            click_on 'アイテムを追加する'
+            fill_in 'keyword', with: 'テストアイテム'
+            find('.input-group-append button').click
+          end
+          within '#search-item-list' do
+            all('li')[0].click_on '追加'
+          end
+          expect(page).to have_content 'アイテムを追加することができませんでした'
+        end.to change { user.items.count }.by(0)
+      end
+    end
+  end
+
+  describe 'アイテム削除機能' do
+    context 'アイテム削除ボタンを押下したとき' do
+      let(:user) { create(:user) }
+      before do
+        @item = create(:item, user: user)
+      end
+
+      it 'そのアイテムがマイアイテムから削除されること', js: true do
+        visit user_items_path(user)
+        expect do
+          click_on "my-item-menu-#{@item.id}"
+          click_on '削除'
+          page.accept_confirm
+          expect(page).to have_content "#{@item.name} を削除しました"
+        end.to change { user.items.count }.by(-1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #181
  
# 実装内容
- アイテム画像の保存に`CerrierWave`を使用
  - Item モデルに`MountUploader`を設定
  - 画像がない場合、デフォルトの画像を表示するように設定
- `items_conntroller` にストロングパラメーターを設定
- アイテム画像の初期データ、テストデータの属性名を`remote_image_url`に変更
## テスト内容
### アイテム追加機能
- アイテム検索のとき、外部API を呼び出さないようにモックを使用
- 検索したアイテムの追加ボタンを押下したとき
  - そのアイテムがマイアイテムページで表示されていること
  - マイアイテム数が1つ増えること
- 追加ボタンを押下したアイテムが既に登録されている場合
  - エラーが発生すること
  - マイアイテム数が変化しないこと
  
### アイテム削除機能
- マイアイテムの削除ボタンを押下したとき
  - そのアイテムが削除されること
  - マイアイテム数が1つ減ること