### PR TITLE
投稿検索機能のシステムスペックを追加

### DIFF
--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -7,16 +7,16 @@
   <hr>
   <div class="form-group mt-3">
     <i class="fas fa-tag tag-color"></i>
-    <%= form.label :tags_id_in, "タグ", class: "font-weight-bold" %>
+    <span class="font-weight-bold">タグ</span>
     <ul class="row px-3">
-      <%= form.collection_check_boxes :tags_id_in, Tag.all, :id, :name, include_hidden: false do |form| %>
+      <%= form.collection_check_boxes :tags_id_in, Tag.all.order(id: :asc), :id, :name, include_hidden: false do |b| %>
         <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
-          <label class="border rounded-pill w-100">
-            <%= form.check_box class: "d-none" %>
-            <span class="d-flex justify-content-center rounded-pill">
-              <%= form.text %>
+          <%= b.label class: "border rounded-pill w-100" do %>
+            <%= b.check_box class: "checkbox-visibility" %>
+            <span class="d-flex justify-content-center rounded-pill w-100 checkbox-position">
+              <%= b.text %>
             </span>
-          </label>
+          <% end %>
         </li>
       <% end %>
     </ul>
@@ -24,16 +24,16 @@
   <hr>
   <div class="form-group mt-3">
     <i class="fas fa-folder category-color"></i>
-    <%= form.label :categories_id_in, "カテゴリー", class: "font-weight-bold" %>
+    <span class="font-weight-bold">カテゴリ</span>
     <ul class="row px-3">
-      <%= form.collection_check_boxes :categories_id_in, Category.all, :id, :name, include_hidden: false do |form| %>
+      <%= form.collection_check_boxes :categories_id_in, Category.all.order(id: :asc), :id, :name, include_hidden: false do |b| %>
         <li class="form-check col-6 col-md-4 col-lg-2 flex-wrap px-2">
-          <label class="rounded-pill w-100">
-            <%= form.check_box class: "d-none" %>
-            <span class="d-flex justify-content-center border rounded-pill">
-              <%= form.text %>
+          <%= b.label class: "rounded-pill w-100" do %>
+            <%= b.check_box class: "checkbox-visibility" %>
+            <span class="d-flex justify-content-center border rounded-pill w-100 checkbox-position">
+              <%= b.text %>
             </span>
-          </label>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/spec/system/searches_spec.rb
+++ b/spec/system/searches_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe "Searches", type: :system do
+  before do
+    visit new_user_session_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: user.password
+    click_button 'ログイン'
+  end
+
+  describe '投稿検索機能' do
+    let(:user) { create(:user) }
+    before do
+      FactoryBot.rewind_sequences
+      create_list(:post, 2)
+      visit current_path
+    end
+
+    context '検索条件を設定した場合' do
+      let(:post) { Post.first }
+      it 'その条件を含む投稿が表示されること', js: true do
+        find('.navbar-toggler').click
+        within '.navbar-collapse' do
+          click_on '検索する'
+        end
+        within '.modal-content' do
+          fill_in 'キーワード', with: post.content
+          find('label', text: post.tags.first.name).click
+          find('label', text: post.categories.first.name).click
+          click_on '検索する'
+        end
+        within first('.card') do
+          expect(page).to have_content post.content
+          # expect(page).to have_content post.tags.first.name
+          # expect(page).to have_content post.categories.first.name
+        end
+      end
+    end
+
+    context '条件を設定しない場合' do
+      let(:post_last) { Post.last }
+      it '投稿日時が降順で表示されること', js: true do
+        find('.navbar-toggler').click
+        within '.navbar-collapse' do
+          click_on '検索する'
+        end
+        within '.modal-content' do
+          click_on '検索する'
+        end
+        within first('.card') do
+          expect(page).to have_content post_last.content
+          # expect(page).to have_content post_last.tags.first.name
+          # expect(page).to have_content post_last.categories.first.name
+        end
+      end
+    end
+
+    context '検索条件が一致する投稿がない場合' do
+      it '投稿が表示されないこと', js: true do
+        find('.navbar-toggler').click
+        within '.navbar-collapse' do
+          click_on '検索する'
+        end
+        within '.modal-content' do
+          fill_in 'キーワード', with: 'テスト投稿'
+          click_on '検索する'
+        end
+        expect(page).not_to have_selector '.card'
+        expect(page).to have_content '検索結果が見つかりませんでした'
+      end
+    end
+
+    context '検索モーダルでリセットボタンを押下したとき' do
+      it '設定済みの検索条件が一括リセットされること', js: true do
+        find('.navbar-toggler').click
+        within '.navbar-collapse' do
+          click_on '検索する'
+        end
+        within '.modal-content' do
+          fill_in 'キーワード', with: 'テスト投稿'
+          find('label', text: 'タグ1').click
+          find('label', text: 'カテゴリ1').click
+          click_on 'リセット'
+          expect(page).not_to have_field 'キーワード', with: 'テスト投稿'
+          expect(page).to have_unchecked_field('タグ1', visible: :hidden)
+          expect(page).to have_unchecked_field('カテゴリ1', visible: :hidden)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/searches_spec.rb
+++ b/spec/system/searches_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe "Searches", type: :system do
+RSpec.describe '投稿検索機能', type: :system do
   before do
     visit new_user_session_path
     fill_in 'メールアドレス', with: user.email
@@ -8,7 +8,7 @@ RSpec.describe "Searches", type: :system do
     click_button 'ログイン'
   end
 
-  describe '投稿検索機能' do
+  describe '投稿検索モーダル' do
     let(:user) { create(:user) }
     before do
       FactoryBot.rewind_sequences


### PR DESCRIPTION
close #187
  
## 実装内容
- 検索モーダルのタグ・カテゴリのラベルとフォームが関連付くようにビューを修正
- システムスペックの追加
  
### テスト内容
- 検索条件を設定した場合、その条件を含む投稿が表示されること
- 条件を設定しない場合、投稿日時が降順で表示されること
- 検索条件が一致する投稿がない場合、投稿が表示されないこと
- 検索モーダルでリセットボタンを押下したとき、設定済みの検索条件が一括リセットされること
  
## 動作確認
- [ ] `rubocop -A`を実行
- [ ] `bundle exec rails_best_practices .`を実行
- [ ] `bundle exec rspec spec/system/searches_spec.rb`を実行してテストが通過することを確認