### PR TITLE
コメント機能のシステムスペックを追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :set_post
+  before_action :set_post, on: :create
   def create
     @comment = @post.comments.build(comment_params)
     if @comment.save
@@ -10,8 +10,7 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = Comment.find(params[:id])
-    @comment.destroy!
+    @comment = current_user.comments.find_by(id: params[:id]).destroy!
     flash.now[:alert] = 'コメントを削除しました'
   end
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [post, comment], class: "form-inline", local: false do |form| %>
-  <div id="comment-error-messages">
+  <div class="w-100" id="comment-error-messages">
     <%= render "layouts/error_messages", model: comment %>
   </div>
   <div class="form-group w-100">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,8 +2,10 @@
   <div id="comment-error-messages">
     <%= render "layouts/error_messages", model: comment %>
   </div>
-  <%= form.hidden_field :user_id, value: current_user.id %>
-  <%= form.hidden_field :post_id, value: post.id %>
-  <%= form.text_area :content, class: "form-control comment-form flex-grow-1", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
-  <%= form.submit "投稿する", class: "btn btn-info ml-auto" %>
+  <div class="form-group w-100">
+    <%= form.hidden_field :user_id, value: current_user.id %>
+    <%= form.hidden_field :post_id, value: post.id %>
+    <%= form.text_area :content, class: "form-control comment-form flex-grow-1", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
+    <%= form.submit "送信する", class: "btn btn-info ml-auto" %>
+  </div>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -110,7 +110,7 @@
                 <%= render "marks_count", post: @post %>
               </div>
             </div>
-            <div class="card-form p-3">
+            <div class="comment-group p-3">
               <%= render partial: "comments/form", locals: {post: @post, comment: @comment} %>
             </div>
           </div>

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'コメント機能', type: :system do
+  before do
+    visit new_user_session_path
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: user.password
+    click_button 'ログイン'
+  end
+
+  describe 'コメント追加' do
+    let(:user) { create(:user) }
+    let(:post) { create(:post) }
+    context '投稿にコメントした場合' do
+      let(:comment) { build(:comment, user: user) }
+      it 'その投稿のコメント数が1つ増えること', js: true do
+        visit post_path(post)
+        expect do
+          within '.comment-container' do
+            expect(page).not_to have_content comment.content
+          end
+          within '.comment-group' do
+            find('#comment_content').set(comment.content)
+            click_on '送信する'
+          end
+          within '.comment-container' do
+            expect(page).to have_content comment.content
+          end
+          expect(page).to have_selector '#flash-messages', text: 'コメントを投稿しました'
+        end.to change { post.comments.count }.by(1)
+      end
+    end
+
+    context '投稿のコメントを削除した場合' do
+      before do
+        @comment = create(:comment, post: post, user: user)
+        create(:comment, post: post)
+      end
+
+      it 'その投稿のコメント数が1つ減ること', js: true do
+        visit post_path(post)
+        expect do
+          within '.comment-container' do
+            expect(page).to have_content @comment.content
+            find("a[href='#{post_comment_path(post, @comment)}']").click
+            page.accept_confirm
+            expect(page).not_to have_content @comment.content
+          end
+          expect(page).to have_selector '#flash-messages', text: 'コメントを削除しました'
+        end.to change { post.comments.count }.by(-1)
+      end
+    end
+
+    context 'コメントが条件を満たさない場合' do
+      it 'エラーメッセージが表示され、コメントが作成されないこと', js: true do
+        visit post_path(post)
+        expect do
+          within '.comment-group' do
+            find('#comment_content').set('')
+            click_on '送信する'
+          end
+          expect(page).to have_selector '#comment-error-messages', text: 'コメント内容を入力してください'
+        end.to change { post.comments.count }.by(0)
+      end
+    end
+  end
+end

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -51,15 +51,14 @@ RSpec.describe 'コメント機能', type: :system do
       end
     end
 
-    context 'コメントが条件を満たさない場合' do
-      it 'エラーメッセージが表示され、コメントが作成されないこと', js: true do
+    context 'コメントを空で送信しようとした場合' do
+      it 'コメントが作成されないこと', js: true do
         visit post_path(post)
         expect do
           within '.comment-group' do
             find('#comment_content').set('')
             click_on '送信する'
           end
-          expect(page).to have_selector '#comment-error-messages', text: 'コメント内容を入力してください'
         end.to change { post.comments.count }.by(0)
       end
     end


### PR DESCRIPTION
close #188
  
## 実装内容
- コメントフォームのビューを修正
  - グループ化して`width`を100%に設定
  - コメント作成ボタンの文言を`送信する`に修正
- コメント作成失敗時のエラーメッセージのスタイルを修正
  - `width`を100%に設定
- コメントコントローラの`set_post`の呼び出しを`create`アクション時のみに修正
- コメント削除時にカレントユーザーの投稿の中からコメントを見つけるように修正
- コメント機能のシステムスペックを作成
  
### テスト内容
- コメントを入力した場合
  - その投稿にコメントが表示されること
  - その投稿のコメント数が1つ増えること
- コメントを削除した場合
  - その投稿にコメントが表示されていないこと
  - その投稿のコメント数が1つ減ること
- コメントが条件を満たさなかった場合
  - エラーが発生すること
  - コメントが作成されないこと
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/system/comments_spec.rb`を実行してテストが通過することを確認