### PR TITLE
bootstrapのカラーユーティリティに色を追加

### DIFF
--- a/app/assets/stylesheets/_valiables.scss
+++ b/app/assets/stylesheets/_valiables.scss
@@ -3,4 +3,5 @@ $dark-gray: #808080;
 $light-gray: #EEEDEC;
 $gold: #BAA877;
 $silver: #A8A9A8;
-$koppar: #947B60
+$koppar: #947B60;
+$bitter-orange: #A36A31;

--- a/app/assets/stylesheets/_valiables.scss
+++ b/app/assets/stylesheets/_valiables.scss
@@ -1,0 +1,6 @@
+$main: #A40000;
+$dark-gray: #808080;
+$light-gray: #EEEDEC;
+$gold: #BAA877;
+$silver: #A8A9A8;
+$koppar: #947B60

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,7 +19,8 @@
 $theme-colors: (
 	"main": $main,
   "dark-gray": $dark-gray,
-  "light-gray": $light-gray
+  "light-gray": $light-gray,
+  "bitter-orange": $bitter-orange
 );
 
 // Sprockets で Bootstrap を扱うためにインクルード

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,10 +15,11 @@
  */
 
 // Bootstrap に color を追加
+@import 'valiables';
 $theme-colors: (
-	"main": #A40000,
-  "gray": #808080,
-  "light-gray": #F3F3F3
+	"main": $main,
+  "dark-gray": $dark-gray,
+  "light-gray": $light-gray
 );
 
 // Sprockets で Bootstrap を扱うためにインクルード
@@ -35,7 +36,7 @@ body {
   margin: 0;
   padding-top: 56px;
   padding-bottom: 56px;
-  background-color: #EEEDEC;
+  background-color: $light-gray;
   min-height: 100vh;
   @media (max-width: 575.98px) {
     padding-bottom: 54px;
@@ -119,11 +120,11 @@ a:hover {
 }
 
 .tag-color {
-  color: #baa877;
+  color: $gold;
 }
 
 .category-color {
-  color: #a8a9a8;
+  color: $silver;
 }
 
 .post-preview-image {
@@ -145,8 +146,8 @@ a:hover {
 }
 
 input:checked + span {
-  color: #EEEDEC;
-  background-color: #808080;
+  color: white;
+  background-color: $dark-gray;
 }
 
 .dropdown-item {
@@ -172,8 +173,8 @@ input:checked + span {
   }
   .active .page-link {
     border-radius: 50%;
-    background-color: #6c757d;
-    color: #f8f9fa;
+    background-color: $dark-gray;
+    color: white;
   }
   .disabled .page-link {
     background-color: transparent;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,14 @@
  *= require_tree .
  *= require_self
  */
+
+// Bootstrap に color を追加
+$theme-colors: (
+	"main": #A40000,
+  "gray": #999999,
+  "light-gray": #F3F3F3
+);
+
 // Sprockets で Bootstrap を扱うためにインクルード
 @import "bootstrap/scss/bootstrap";
 // FontAwesome を扱うためにインクルード

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,7 @@
 // Bootstrap に color を追加
 $theme-colors: (
 	"main": #A40000,
-  "gray": #999999,
+  "gray": #808080,
   "light-gray": #F3F3F3
 );
 
@@ -146,7 +146,7 @@ a:hover {
 
 input:checked + span {
   color: #EEEDEC;
-  background-color: #6c757d;
+  background-color: #808080;
 }
 
 .dropdown-item {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -152,10 +152,10 @@ input:checked + span {
 
 .dropdown-item {
   &:hover {
-    background-color: #e4e8ec;
+    opacity: 0.6;
+    background-color: transparent;
   }
   &:active {
-    background-color: #e4e8ec;
     color: #212529;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -158,3 +158,24 @@ input:checked + span {
     color: #212529;
   }
 }
+
+#custom-pagination {
+  justify-content: center;
+  .page-link {
+    background-color: transparent;
+    border: 0;
+    color: unset;
+    &:hover {
+      border-radius: 50%;
+      background-color: #dedcda;
+    }
+  }
+  .active .page-link {
+    border-radius: 50%;
+    background-color: #6c757d;
+    color: #f8f9fa;
+  }
+  .disabled .page-link {
+    background-color: transparent;
+  }
+}

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -2,6 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@import 'valiables';
+
 .key-visual-left {
   min-height: 80vh;
   background-image: url("top_left_reverse.jpg");
@@ -49,6 +51,6 @@
     height: 3px;
     content: '';
     border-radius: 3px;
-    background: #6c757d;
+    background: $dark-gray;
   }
 }

--- a/app/assets/stylesheets/know_hows.scss
+++ b/app/assets/stylesheets/know_hows.scss
@@ -2,11 +2,12 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@import 'valiables';
 
 .know-how-genre {
   position: relative;
-  background: rgba(186, 168, 119, 0.7);
-  box-shadow: 0px 0px 0px 5px rgba(186, 168, 119, 0.7);
+  background: $gold;
+  box-shadow: 0px 0px 0px 5px $gold;
   border: dashed 2px #f8f9fa;
   padding: 0.5em 0.75em;
   color: #212529;
@@ -19,7 +20,7 @@
   top: -7px;
   border-width: 0 0 15px 15px;
   border-style: solid;
-  border-color: #EEEDEC #EEEDEC rgb(186, 168, 119);
+  border-color: $light-gray $light-gray $koppar;
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.15);
 }
 
@@ -31,6 +32,6 @@
   padding: 0.4em 0.5em;
   color: #212529;
   background: #f4f4f4;
-  border-left: solid 5px rgba(186, 168, 119, 0.7);
-  border-bottom: solid 3px #d7d7d7;
+  border-left: solid 5px $gold;
+  border-bottom: solid 3px $dark-gray;
 }

--- a/app/assets/stylesheets/know_hows.scss
+++ b/app/assets/stylesheets/know_hows.scss
@@ -10,7 +10,6 @@
   box-shadow: 0px 0px 0px 5px $gold;
   border: dashed 2px #f8f9fa;
   padding: 0.5em 0.75em;
-  color: #212529;
 }
 
 .know-how-genre:after {
@@ -30,7 +29,6 @@
 
 #know-how-modal-title {
   padding: 0.4em 0.5em;
-  color: #212529;
   background: #f4f4f4;
   border-left: solid 5px $gold;
   border-bottom: solid 3px $dark-gray;

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -2,10 +2,12 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@import 'valiables';
+
 .like-color {
-  color: #a40000;
+  color: $main;
 }
 
 .dislike-color {
-  color: #6c757d;
+  color: $dark-gray;
 }

--- a/app/assets/stylesheets/marks.scss
+++ b/app/assets/stylesheets/marks.scss
@@ -2,10 +2,12 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@import 'valiables';
+
 .mark-color {
-  color: #947b60;
+  color: $koppar;
 }
 
 .unmark-color {
-  color: #6c757d;
+  color: $dark-gray;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -2,6 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@import 'valiables';
+
 .carousel-indicators {
   .indicators-icon {
     border-radius: 50%;
@@ -56,8 +58,8 @@
   width: calc(100% / 2);
   padding-top: calc((100% / 2) - 4px );
   margin: 0;
-  background: #f7f7f7;
-  border: 2px dashed #9c9c9c;
+  background: $light-gray;
+  border: 2px dashed $dark-gray;
   cursor: pointer;
 }
 
@@ -68,5 +70,5 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #9c9c9c;
+  color: $dark-gray;
 }

--- a/app/assets/stylesheets/progresses.scss
+++ b/app/assets/stylesheets/progresses.scss
@@ -1,3 +1,13 @@
 // Place all the styles related to the progresses controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+@import 'valiables';
+
+.check-color {
+  color: $main;
+}
+
+.uncheck-color {
+  color: $dark-gray;
+}

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -27,27 +27,6 @@
   }
 }
 
-#custom-pagination {
-  justify-content: center;
-  .page-link {
-    background-color: transparent;
-    border: 0;
-    color: unset;
-    &:hover {
-      border-radius: 50%;
-      background-color: #dedcda;
-    }
-  }
-  .active .page-link {
-    border-radius: 50%;
-    background-color: #6c757d;
-    color: #f8f9fa;
-  }
-  .disabled .page-link {
-    background-color: transparent;
-  }
-}
-
 .fadein-image {
   animation: fadein 2s forwards;
 }

--- a/app/javascript/packs/collapse.js
+++ b/app/javascript/packs/collapse.js
@@ -1,12 +1,12 @@
 $(document).on('turbolinks:load', function(){
   $(function(){
     function iconUpdate(collapseButton){
-      if ($(collapseButton).hasClass('btn-outline-secondary')) {
-        $(collapseButton).toggleClass('btn-secondary btn-outline-secondary');
+      if ($(collapseButton).hasClass('btn-outline-gray')) {
+        $(collapseButton).toggleClass('btn-gray btn-outline-gray');
         const icon = $(collapseButton).children();
         $(icon).toggleClass('fa-plus fa-minus');
       } else {
-        $(collapseButton).toggleClass('btn-secondary btn-outline-secondary');
+        $(collapseButton).toggleClass('btn-gray btn-outline-gray');
         const icon = $(collapseButton).children();
         $(icon).toggleClass('fa-plus fa-minus');
       }

--- a/app/javascript/packs/collapse.js
+++ b/app/javascript/packs/collapse.js
@@ -1,12 +1,12 @@
 $(document).on('turbolinks:load', function(){
   $(function(){
     function iconUpdate(collapseButton){
-      if ($(collapseButton).hasClass('btn-outline-gray')) {
-        $(collapseButton).toggleClass('btn-gray btn-outline-gray');
+      if ($(collapseButton).hasClass('btn-outline-dark-gray')) {
+        $(collapseButton).toggleClass('btn-dark-gray btn-outline-dark-gray');
         const icon = $(collapseButton).children();
         $(icon).toggleClass('fa-plus fa-minus');
       } else {
-        $(collapseButton).toggleClass('btn-gray btn-outline-gray');
+        $(collapseButton).toggleClass('btn-dark-gray btn-outline-dark-gray');
         const icon = $(collapseButton).children();
         $(icon).toggleClass('fa-plus fa-minus');
       }

--- a/app/javascript/packs/jscroll.js
+++ b/app/javascript/packs/jscroll.js
@@ -4,7 +4,7 @@ $(document).on('turbolinks:load', function(){
     if (windowSize < 576) {
       function jscrollOption(jscrollId){
         const Option = {
-          loadingHtml: '<div class="d-flex justify-content-center"><div class="spinner-border text-gray" role="status"><span class="sr-only">Loading...</span></div></div>',
+          loadingHtml: '<div class="d-flex justify-content-center"><div class="spinner-border text-dark-gray" role="status"><span class="sr-only">Loading...</span></div></div>',
           autoTrigger: true,
           padding: 100,
           nextSelector: 'a[rel=next]',

--- a/app/javascript/packs/jscroll.js
+++ b/app/javascript/packs/jscroll.js
@@ -4,7 +4,7 @@ $(document).on('turbolinks:load', function(){
     if (windowSize < 576) {
       function jscrollOption(jscrollId){
         const Option = {
-          loadingHtml: '<div class="d-flex justify-content-center"><div class="spinner-border text-secondary" role="status"><span class="sr-only">Loading...</span></div></div>',
+          loadingHtml: '<div class="d-flex justify-content-center"><div class="spinner-border text-gray" role="status"><span class="sr-only">Loading...</span></div></div>',
           autoTrigger: true,
           padding: 100,
           nextSelector: 'a[rel=next]',

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -33,7 +33,7 @@ $(document).on('turbolinks:load', function () {
         fileReader.onloadend = function() {
           const html = `<div class="preview-item" data-id="${file.id}">
                         <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
                       </div>`;
           $(`#${action}-drop`).before($(html));
           const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;
@@ -128,7 +128,7 @@ $(document).on('turbolinks:load', function () {
           fileReader.onloadend = function() {
             const html = `<div class="preview-item" data-id="${file.id}">
                         <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
                       </div>`;
             $(`#${action}-drop`).before($(html));
             const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;

--- a/app/javascript/packs/photos_preview.js
+++ b/app/javascript/packs/photos_preview.js
@@ -33,7 +33,7 @@ $(document).on('turbolinks:load', function () {
         fileReader.onloadend = function() {
           const html = `<div class="preview-item" data-id="${file.id}">
                         <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
                       </div>`;
           $(`#${action}-drop`).before($(html));
           const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;
@@ -97,12 +97,12 @@ $(document).on('turbolinks:load', function () {
       //ドロップエリアの上にある時に発火するイベント
       dropArea.addEventListener("dragover", function(e){
         e.preventDefault();
-        $(this).css({'border': '2px solid #9e9e9e', 'opacity': '0.5'});
+        $(this).css({'border': '2px solid $dark-gray', 'opacity': '0.5'});
       },false);
       //ドロップエリアから離れた時に発火するイベント
       dropArea.addEventListener("dragleave", function(e){
         e.preventDefault();
-        $(this).css({'border': '2px dashed #9c9c9c', 'background': '#f7f7f7', 'opacity': '1.0'});
+        $(this).css({'border': '2px dashed $dark-gray', 'opacity': '1.0'});
       },false);
       // ドロップしたときに発火するイベント
       dropArea.addEventListener("drop", function(e) {
@@ -116,7 +116,7 @@ $(document).on('turbolinks:load', function () {
           fileField = new_file_field
         }  
         e.preventDefault();
-        $(this).css({'border': '2px dashed #9c9c9c', 'background': '#f7f7f7', 'opacity': '1.0'});
+        $(this).css({'border': '2px dashed $dark-gray', 'opacity': '1.0'});
         const files = e.dataTransfer.files;
         $.each(files, function(i, file){
           const fileReader = new FileReader();
@@ -128,7 +128,7 @@ $(document).on('turbolinks:load', function () {
           fileReader.onloadend = function() {
             const html = `<div class="preview-item" data-id="${file.id}">
                         <img src="${fileReader.result}" class="preview-image">
-                        <button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="${action}"><i class="fas fa-times"></i></button>
                       </div>`;
             $(`#${action}-drop`).before($(html));
             const previewItemLength = $(`#${action}-drop`).prevAll('.preview-item').length;

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -20,7 +20,7 @@ $(document).on('turbolinks:load', function() {
         photos.forEach(function(photo){
         const html = `<div class="preview-item" data-id="photos-${photo.id}">
                         <img src="${photo.image.url}" class="preview-image">
-                        <button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
                       </div>`;
           $('#edit-drop').before($(html));
           const previewItemLength = $('#edit-drop').prevAll('.preview-item').length;

--- a/app/javascript/packs/post_edit.js
+++ b/app/javascript/packs/post_edit.js
@@ -20,7 +20,7 @@ $(document).on('turbolinks:load', function() {
         photos.forEach(function(photo){
         const html = `<div class="preview-item" data-id="photos-${photo.id}">
                         <img src="${photo.image.url}" class="preview-image">
-                        <button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
+                        <button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview" data-action="edit"><i class="fas fa-times"></i></button>
                       </div>`;
           $('#edit-drop').before($(html));
           const previewItemLength = $('#edit-drop').prevAll('.preview-item').length;

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -13,7 +13,7 @@ $(document).on('turbolinks:load', function(){
             dataBox.items.add(avatar)
             fileReader.onloadend = function(){
                 const avatarImage = `<img src="${fileReader.result}" class="rounded-circle avatar-preview bg-light">`;
-                const deleteButton = '<button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
+                const deleteButton = '<button type="button" class="btn btn-dark-gray btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
                 $('.avatar-label').prepend(avatarImage).after(deleteButton);
             };
             fileReader.readAsDataURL(avatar);

--- a/app/javascript/packs/preview.js
+++ b/app/javascript/packs/preview.js
@@ -13,7 +13,7 @@ $(document).on('turbolinks:load', function(){
             dataBox.items.add(avatar)
             fileReader.onloadend = function(){
                 const avatarImage = `<img src="${fileReader.result}" class="rounded-circle avatar-preview bg-light">`;
-                const deleteButton = '<button type="button" class="btn btn-dark btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
+                const deleteButton = '<button type="button" class="btn btn-gray btn-sm rounded-circle delete-preview"><i class="fas fa-times"></i></button>';
                 $('.avatar-label').prepend(avatarImage).after(deleteButton);
             };
             fileReader.readAsDataURL(avatar);

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -6,6 +6,6 @@
     <%= form.hidden_field :user_id, value: current_user.id %>
     <%= form.hidden_field :post_id, value: post.id %>
     <%= form.text_area :content, class: "form-control comment-form flex-grow-1", placeholder: "コメント...", required: true, maxlength: 140, rows: "1" %>
-    <%= form.submit "送信する", class: "btn btn-info ml-auto" %>
+    <%= form.submit "送信する", class: "btn btn-main ml-auto" %>
   </div>
 <% end %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.resend_confirmation_instructions'), class: 'btn btn-primary' %>
+    <%= f.submit t('.resend_confirmation_instructions'), class: 'btn btn-main' %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -19,7 +19,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.change_my_password'), class: 'btn btn-primary' %>
+    <%= f.submit t('.change_my_password'), class: 'btn btn-main' %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.send_me_reset_password_instructions'), class: 'btn btn-info btn-block' %>
+    <%= f.submit t('.send_me_reset_password_instructions'), class: 'btn btn-main btn-block' %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -90,7 +90,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.update'), class: 'btn btn-info btn-block' %>
+    <%= f.submit t('.update'), class: 'btn btn-main btn-block' %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -97,5 +97,5 @@
 <hr class="devise-link my-4">
 
 <div class="form-group">
-  <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'btn btn-secondary btn-block' %>
+  <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'btn btn-gray btn-block' %>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -97,5 +97,5 @@
 <hr class="devise-link my-4">
 
 <div class="form-group">
-  <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'btn btn-gray btn-block' %>
+  <%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'btn btn-dark-gray btn-block' %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -80,7 +80,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.sign_up'), class: 'btn btn-info btn-block' %>
+    <%= f.submit t('.sign_up'), class: 'btn btn-main btn-block' %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -25,7 +25,7 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.submit  t('.sign_in'), class: 'btn btn-info btn-block' %>
+    <%= f.submit t('.sign_in'), class: 'btn btn-main btn-block' %>
   </div>
 <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-gray btn-block' %><br />
+    <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-dark-gray btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -8,7 +8,7 @@
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-gray btn-block' %><br />
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-dark-gray btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,6 +1,6 @@
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
+    <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-gray btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
@@ -8,7 +8,7 @@
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-gray btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit t('.resend_unlock_instructions'), class: 'btn btn-primary'%>
+    <%= f.submit t('.resend_unlock_instructions'), class: 'btn btn-main'%>
   </div>
 <% end %>
 

--- a/app/views/graphs/_collapse.html.erb
+++ b/app/views/graphs/_collapse.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="col-12 col-lg-8">
       <p class="d-flex justify-content-center m-0">
-        <button class="btn btn-outline-gray btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
+        <button class="btn btn-outline-dark-gray btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
       </p>
       <div class="row">
         <div class="col">

--- a/app/views/graphs/_collapse.html.erb
+++ b/app/views/graphs/_collapse.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="col-12 col-lg-8">
       <p class="d-flex justify-content-center m-0">
-        <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
+        <button class="btn btn-outline-gray btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#<%= table %>" aria-expanded="false" aria-controls="<%= table %>" id="collapse-<%= table %>">詳細<i class="fas fa-plus ml-3"></i></button>
       </p>
       <div class="row">
         <div class="col">

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -12,7 +12,7 @@
           <div class="d-inline-flex flex-column">
             <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
             <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
-            <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
+            <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
           </div>
         </div>
       <% end %>
@@ -119,7 +119,7 @@
         <% unless user_signed_in? %>
           <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
           <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
-          <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
+          <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
         <% end %>
       </div>
     </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -11,7 +11,7 @@
         <div class="ml-auto ml-sm-0 px-4">
           <div class="d-inline-flex flex-column">
             <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-gray mb-3" %>
+            <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
             <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
           </div>
         </div>
@@ -118,7 +118,7 @@
       <div class="d-inline-flex flex-column">
         <% unless user_signed_in? %>
           <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-gray mb-3" %>
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
           <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
         <% end %>
       </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -11,7 +11,7 @@
         <div class="ml-auto ml-sm-0 px-4">
           <div class="d-inline-flex flex-column">
             <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-info mb-3" %>
+            <%= link_to "ログイン", new_user_session_path, class: "btn btn-gray mb-3" %>
             <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
           </div>
         </div>
@@ -118,7 +118,7 @@
       <div class="d-inline-flex flex-column">
         <% unless user_signed_in? %>
           <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-info mb-3" %>
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-gray mb-3" %>
           <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
         <% end %>
       </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -10,7 +10,7 @@
       <% unless user_signed_in? %>
         <div class="ml-auto ml-sm-0 px-4">
           <div class="d-inline-flex flex-column">
-            <%= link_to "会員登録", new_user_registration_path, class: "btn btn-info mb-3" %>
+            <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
             <%= link_to "ログイン", new_user_session_path, class: "btn btn-info mb-3" %>
             <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
           </div>
@@ -117,7 +117,7 @@
     <div class="d-flex justify-content-center">
       <div class="d-inline-flex flex-column">
         <% unless user_signed_in? %>
-          <%= link_to "会員登録", new_user_registration_path, class: "btn btn-info mb-3" %>
+          <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
           <%= link_to "ログイン", new_user_session_path, class: "btn btn-info mb-3" %>
           <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-success mb-3 guest-login" %>
         <% end %>

--- a/app/views/inquiries/_confirmed.html.erb
+++ b/app/views/inquiries/_confirmed.html.erb
@@ -16,6 +16,6 @@
 </div>
 <hr class="py-2 m-0">
 <div class="form-group">
-  <%= form.button "この内容で送信する", class: 'btn btn-info btn-block', name: "inquiry[confirmed]", value: "1" %>
+  <%= form.button "この内容で送信する", class: 'btn btn-main btn-block', name: "inquiry[confirmed]", value: "1" %>
   <%= form.button "入力画面に戻る", class: 'btn btn-secondary btn-block', name: "inquiry[confirmed]", value: "" %>
 </div>

--- a/app/views/inquiries/_confirmed.html.erb
+++ b/app/views/inquiries/_confirmed.html.erb
@@ -17,5 +17,5 @@
 <hr class="py-2 m-0">
 <div class="form-group">
   <%= form.button "この内容で送信する", class: 'btn btn-main btn-block', name: "inquiry[confirmed]", value: "1" %>
-  <%= form.button "入力画面に戻る", class: 'btn btn-secondary btn-block', name: "inquiry[confirmed]", value: "" %>
+  <%= form.button "入力画面に戻る", class: 'btn btn-gray btn-block', name: "inquiry[confirmed]", value: "" %>
 </div>

--- a/app/views/inquiries/_confirmed.html.erb
+++ b/app/views/inquiries/_confirmed.html.erb
@@ -17,5 +17,5 @@
 <hr class="py-2 m-0">
 <div class="form-group">
   <%= form.button "この内容で送信する", class: 'btn btn-main btn-block', name: "inquiry[confirmed]", value: "1" %>
-  <%= form.button "入力画面に戻る", class: 'btn btn-gray btn-block', name: "inquiry[confirmed]", value: "" %>
+  <%= form.button "入力画面に戻る", class: 'btn btn-dark-gray btn-block', name: "inquiry[confirmed]", value: "" %>
 </div>

--- a/app/views/inquiries/_submitted.html.erb
+++ b/app/views/inquiries/_submitted.html.erb
@@ -24,5 +24,5 @@
 </div>
 <hr class="py-2 m-0">
 <div class="form-group">
-  <%= form.submit "入力内容を確認", class: 'btn btn-info btn-block' %>
+  <%= form.submit "入力内容を確認", class: 'btn btn-main btn-block' %>
 </div>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -15,7 +15,7 @@
           <button class="btn btn-link btn-sm text-reset p-0" type="button" id="my-item-menu-<%= item.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fas fa-ellipsis-h"></i>
           </button>
-          <div class="dropdown-menu dropdown-menu-right bg-light text-center" aria-labelledby="my-item-menu-<%= item.id %>">
+          <div class="dropdown-menu dropdown-menu-right text-center" aria-labelledby="my-item-menu-<%= item.id %>">
             <%= link_to "削除", user_item_path(current_user, item), class: "dropdown-item text-danger", method: :delete, data: { confirm: "削除しますか?"}, remote: true %>
           </div>
         </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,7 +6,7 @@
 </div>
 <% if current_user.id == @user.id %>
   <div class="search-item-group mb-3">
-    <button class="btn btn-outline-gray btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#search-item" aria-expanded="false" aria-controls="search-item" id="collapse-search-item">
+    <button class="btn btn-outline-dark-gray btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#search-item" aria-expanded="false" aria-controls="search-item" id="collapse-search-item">
       アイテムを追加する<i class="fas fa-plus ml-3"></i>
     </button>
     <div class="collapse item-collapse py-4 mb-4" id="search-item">
@@ -14,7 +14,7 @@
       <div class="input-group px-3">
         <%= form.text_field :keyword, class: "form-control", placeholder: "追加したいアイテムを検索", value: params[:keyword], required: true %>
         <div class="input-group-append">
-          <%= button_tag type: :submit, class: "btn btn-gray" do %>
+          <%= button_tag type: :submit, class: "btn btn-dark-gray" do %>
             <i class="fas fa-search"></i>
           <% end %>
         </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -6,7 +6,7 @@
 </div>
 <% if current_user.id == @user.id %>
   <div class="search-item-group mb-3">
-    <button class="btn btn-outline-secondary btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#search-item" aria-expanded="false" aria-controls="search-item" id="collapse-search-item">
+    <button class="btn btn-outline-gray btn-block collapse-btn" type="button" data-toggle="collapse" data-target="#search-item" aria-expanded="false" aria-controls="search-item" id="collapse-search-item">
       アイテムを追加する<i class="fas fa-plus ml-3"></i>
     </button>
     <div class="collapse item-collapse py-4 mb-4" id="search-item">
@@ -14,7 +14,7 @@
       <div class="input-group px-3">
         <%= form.text_field :keyword, class: "form-control", placeholder: "追加したいアイテムを検索", value: params[:keyword], required: true %>
         <div class="input-group-append">
-          <%= button_tag type: :submit, class: "btn btn-info" do %>
+          <%= button_tag type: :submit, class: "btn btn-gray" do %>
             <i class="fas fa-search"></i>
           <% end %>
         </div>

--- a/app/views/know_hows/_check.html.erb
+++ b/app/views/know_hows/_check.html.erb
@@ -1,3 +1,3 @@
 <%= link_to know_how_progresses_path(know_how), method: :delete, remote: true do %>
-  <i class="fas fa-2x fa-check-square text-success"></i>
+  <i class="fas fa-2x fa-check-square check-color"></i>
 <% end %>

--- a/app/views/know_hows/_know_how.html.erb
+++ b/app/views/know_hows/_know_how.html.erb
@@ -12,7 +12,7 @@
         <div class="px-2">
           <%= know_how.title %>
         </div>
-        <%= link_to know_how_path(know_how), type: "button", class: "btn btn-outline-gray ml-auto d-flex align-items-center", data: { toggle: "modal", target: "#know-how-modal"}, remote: true do %>
+        <%= link_to know_how_path(know_how), type: "button", class: "btn btn-outline-dark-gray ml-auto d-flex align-items-center", data: { toggle: "modal", target: "#know-how-modal"}, remote: true do %>
           <div class="d-none d-sm-block mr-2">
             詳細を見る
           </div>

--- a/app/views/know_hows/_know_how.html.erb
+++ b/app/views/know_hows/_know_how.html.erb
@@ -12,7 +12,7 @@
         <div class="px-2">
           <%= know_how.title %>
         </div>
-        <%= link_to know_how_path(know_how), type: "button", class: "btn btn-outline-secondary ml-auto d-flex align-items-center", data: { toggle: "modal", target: "#know-how-modal"}, remote: true do %>
+        <%= link_to know_how_path(know_how), type: "button", class: "btn btn-outline-gray ml-auto d-flex align-items-center", data: { toggle: "modal", target: "#know-how-modal"}, remote: true do %>
           <div class="d-none d-sm-block mr-2">
             詳細を見る
           </div>

--- a/app/views/know_hows/_show.html.erb
+++ b/app/views/know_hows/_show.html.erb
@@ -10,7 +10,7 @@
       <div class="modal-body">
       <p id="know-how-modal-content"></p>
       <div class="modal-footer">
-        <button type="button" class="btn btn-gray" data-dismiss="modal">閉じる</button>
+        <button type="button" class="btn btn-dark-gray" data-dismiss="modal">閉じる</button>
       </div>
     </div>
   </div>

--- a/app/views/know_hows/_show.html.erb
+++ b/app/views/know_hows/_show.html.erb
@@ -10,7 +10,7 @@
       <div class="modal-body">
       <p id="know-how-modal-content"></p>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+        <button type="button" class="btn btn-gray" data-dismiss="modal">閉じる</button>
       </div>
     </div>
   </div>

--- a/app/views/know_hows/_uncheck.html.erb
+++ b/app/views/know_hows/_uncheck.html.erb
@@ -1,3 +1,3 @@
 <%= link_to know_how_progresses_path(know_how), method: :post, remote: true do %>
-  <i class="far fa-2x fa-square text-muted"></i>
+  <i class="far fa-2x fa-square uncheck-color"></i>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -24,7 +24,7 @@
 <% else %>
   <h3 class="d-flex justify-content-center pt-5">投稿がまだありません</h3>
   <div class="d-flex justify-content-center py-2 flex-wrap">
-    <button type="button" class="btn btn-info btn-sm" data-toggle="modal" data-target="#new-modal">
+    <button type="button" class="btn btn-main btn-sm" data-toggle="modal" data-target="#new-modal">
       <i class="fas fa-plus-square"></i><p class="d-sm-inline d-none"> 投稿する</p>
     </button>
     <span class="d-flex align-items-center ml-1">から新しい投稿をしてみよう！</span>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
     <div class="card mb-6 border-0">
       <div class="row no-gutters">
         <%# 投稿画像を表示 %>
-        <div class="col-md-12 col-xl-6 carousel slide bg-gray" id="carouselExampleIndicators" data-interval="false">
+        <div class="col-md-12 col-xl-6 carousel slide bg-dark-gray" id="carouselExampleIndicators" data-interval="false">
           <% i = 0 %>
           <% if @post.photos.length > 1 %>
             <ol class="carousel-indicators">
@@ -48,7 +48,7 @@
             <% end %>
               <% if current_user.id == @post.user_id %>
                 <div class="dropdown ml-auto">
-                  <div class="btn btn-gray dropdown-toggle btn-sm" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <div class="btn btn-dark-gray dropdown-toggle btn-sm" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <i class="fas fa-cog"></i>
                   </div>
                   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu2">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,7 +4,7 @@
     <div class="card mb-6 border-0">
       <div class="row no-gutters">
         <%# 投稿画像を表示 %>
-        <div class="col-md-12 col-xl-6 carousel slide bg-secondary" id="carouselExampleIndicators" data-interval="false">
+        <div class="col-md-12 col-xl-6 carousel slide bg-gray" id="carouselExampleIndicators" data-interval="false">
           <% i = 0 %>
           <% if @post.photos.length > 1 %>
             <ol class="carousel-indicators">
@@ -48,7 +48,7 @@
             <% end %>
               <% if current_user.id == @post.user_id %>
                 <div class="dropdown ml-auto">
-                  <div class="btn btn-secondary dropdown-toggle btn-sm" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <div class="btn btn-gray dropdown-toggle btn-sm" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <i class="fas fa-cog"></i>
                   </div>
                   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu2">

--- a/app/views/search_items/_search_item.html.erb
+++ b/app/views/search_items/_search_item.html.erb
@@ -10,7 +10,7 @@
           </div>
           <h6 class="px-2 py-2"><%= item["productName"] %></h6>
           <p class="text-muted px-2"><%= item["genreName"] %></p>
-          <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-info mt-auto mx-lg-2" %>
+          <%= link_to "追加", user_items_path(current_user, item: {name: item["productName"], genre: item["genreName"], remote_image_url: item["mediumImageUrl"]}), method: :post, type: "button", class: "btn btn-outline-main mt-auto mx-lg-2" %>
         </li>
       <% end %>
     <% end %>

--- a/app/views/search_items/index.html.erb
+++ b/app/views/search_items/index.html.erb
@@ -8,7 +8,7 @@
   <div class="input-group mb-3">
     <%= form.text_field :keyword, class: "form-control", placeholder: "アイテムを検索", value: params[:keyword], required: true %>
     <div class="input-group-append">
-      <%= button_tag type: :submit, class: "btn btn-info" do %>
+      <%= button_tag type: :submit, class: "btn btn-gray" do %>
         <i class="fas fa-search"></i>
       <% end %>
     </div>

--- a/app/views/search_items/index.html.erb
+++ b/app/views/search_items/index.html.erb
@@ -8,7 +8,7 @@
   <div class="input-group mb-3">
     <%= form.text_field :keyword, class: "form-control", placeholder: "アイテムを検索", value: params[:keyword], required: true %>
     <div class="input-group-append">
-      <%= button_tag type: :submit, class: "btn btn-gray" do %>
+      <%= button_tag type: :submit, class: "btn btn-dark-gray" do %>
         <i class="fas fa-search"></i>
       <% end %>
     </div>

--- a/app/views/shared/_edit_modal_content.html.erb
+++ b/app/views/shared/_edit_modal_content.html.erb
@@ -52,6 +52,6 @@
   <small>* 最大2つまで選択可能です *</small>
   <hr class="py-2 m-0">
   <div class="form-group mt-3">
-    <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'edit-button' %>
+    <%= form.submit '投稿する', class: 'btn btn-main btn-block', id: 'edit-button' %>
   </div>
 <% end %>

--- a/app/views/shared/_header_bottom.html.erb
+++ b/app/views/shared/_header_bottom.html.erb
@@ -4,7 +4,7 @@
     <button type="button" class="btn btn-main" data-toggle="modal" data-target="#new-modal">
       <i class="fas fa-plus-square"></i>
     </button>
-    <button type="button" class="btn btn-outline-gray" data-toggle="modal" data-target="#search-modal">
+    <button type="button" class="btn btn-outline-dark-gray" data-toggle="modal" data-target="#search-modal">
       <i class="fas fa-search"></i>
     </button>
     <%= link_to user_items_path(current_user), class: "nav-item nav-link fa-lg" do %>

--- a/app/views/shared/_header_bottom.html.erb
+++ b/app/views/shared/_header_bottom.html.erb
@@ -4,7 +4,7 @@
     <button type="button" class="btn btn-main" data-toggle="modal" data-target="#new-modal">
       <i class="fas fa-plus-square"></i>
     </button>
-    <button type="button" class="btn btn-outline-secondary" data-toggle="modal" data-target="#search-modal">
+    <button type="button" class="btn btn-outline-gray" data-toggle="modal" data-target="#search-modal">
       <i class="fas fa-search"></i>
     </button>
     <%= link_to user_items_path(current_user), class: "nav-item nav-link fa-lg" do %>

--- a/app/views/shared/_header_bottom.html.erb
+++ b/app/views/shared/_header_bottom.html.erb
@@ -1,7 +1,7 @@
 <% if user_signed_in? %>
 <nav class="navbar navbar-expand navbar-light bg-light fixed-bottom d-sm-none">
   <div class="navbar-nav w-100 justify-content-between">
-    <button type="button" class="btn btn-info" data-toggle="modal" data-target="#new-modal">
+    <button type="button" class="btn btn-main" data-toggle="modal" data-target="#new-modal">
       <i class="fas fa-plus-square"></i>
     </button>
     <button type="button" class="btn btn-outline-secondary" data-toggle="modal" data-target="#search-modal">

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -9,7 +9,7 @@
       <button type="button" class="btn btn-main d-sm-inline d-none" data-toggle="modal" data-target="#new-modal">
         <i class="fas fa-plus-square"></i> 投稿する
       </button>
-      <button type="button" class="btn btn-outline-secondary d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">
+      <button type="button" class="btn btn-outline-gray d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">
         <i class="fas fa-search"></i> 検索する
       </button>
       <%# 要素を右寄せで配置 %>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -9,7 +9,7 @@
       <button type="button" class="btn btn-main d-sm-inline d-none" data-toggle="modal" data-target="#new-modal">
         <i class="fas fa-plus-square"></i> 投稿する
       </button>
-      <button type="button" class="btn btn-outline-gray d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">
+      <button type="button" class="btn btn-outline-dark-gray d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">
         <i class="fas fa-search"></i> 検索する
       </button>
       <%# 要素を右寄せで配置 %>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -6,7 +6,7 @@
 
   <div class="collapse navbar-collapse" id="navbarNav">
     <% if user_signed_in? %>
-      <button type="button" class="btn btn-info d-sm-inline d-none" data-toggle="modal" data-target="#new-modal">
+      <button type="button" class="btn btn-main d-sm-inline d-none" data-toggle="modal" data-target="#new-modal">
         <i class="fas fa-plus-square"></i> 投稿する
       </button>
       <button type="button" class="btn btn-outline-secondary d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">

--- a/app/views/shared/_new_modal_content.html.erb
+++ b/app/views/shared/_new_modal_content.html.erb
@@ -52,6 +52,6 @@
   <small>* 最大2つまで選択可能です *</small>
   <hr class="py-2 m-0">
   <div class="form-group mt-4">
-    <%= form.submit '投稿する', class: 'btn btn-info btn-block', id: 'new-button' %>
+    <%= form.submit '投稿する', class: 'btn btn-main btn-block', id: 'new-button' %>
   </div>
 <% end %>

--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -40,5 +40,5 @@
   </div>
   <hr class="py-2 m-0">
   <%= form.submit "検索する", class: 'btn btn-main btn-block my-3' %>
-  <button type="button" class="btn btn-gray btn-block my-3" id="reset-button">リセット</button>
+  <button type="button" class="btn btn-dark-gray btn-block my-3" id="reset-button">リセット</button>
 <% end %>

--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -39,6 +39,6 @@
     </ul>
   </div>
   <hr class="py-2 m-0">
-  <%= form.submit "検索する", class: 'btn btn-info btn-block my-3' %>
+  <%= form.submit "検索する", class: 'btn btn-main btn-block my-3' %>
   <button type="button" class="btn btn-secondary btn-block my-3" id="reset-button">リセット</button>
 <% end %>

--- a/app/views/shared/_search_modal_content.html.erb
+++ b/app/views/shared/_search_modal_content.html.erb
@@ -40,5 +40,5 @@
   </div>
   <hr class="py-2 m-0">
   <%= form.submit "検索する", class: 'btn btn-main btn-block my-3' %>
-  <button type="button" class="btn btn-secondary btn-block my-3" id="reset-button">リセット</button>
+  <button type="button" class="btn btn-gray btn-block my-3" id="reset-button">リセット</button>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,7 @@
           <button class="btn btn-link text-reset" type="button" id="user-menu-list" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="fas fa-list-ul fa-lg"></i>
           </button>
-          <div class="dropdown-menu dropdown-menu-right bg-light text-center" aria-labelledby="user-menu-list">
+          <div class="dropdown-menu dropdown-menu-right text-center" aria-labelledby="user-menu-list">
             <%= link_to edit_user_registration_path, class: "dropdown-item text-left" do %>
               <i class="fas fa-cog"></i>
               <span class="pl-2">プロフィール編集</span>

--- a/spec/system/progresses_spec.rb
+++ b/spec/system/progresses_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe 'ノウハウチェック機能', type: :system do
         visit know_hows_path
         expect do
           within "#know-how-#{know_how_first.id}" do
-            expect(page).not_to have_css '.text-success'
+            expect(page).not_to have_css '.check-color'
             find("a[href='#{know_how_progresses_path(know_how_first)}']").click
-            expect(page).to have_css '.text-success'
+            expect(page).to have_css '.check-color'
           end
         end.to change { user.progresses.count }.by(1)
       end
@@ -42,9 +42,9 @@ RSpec.describe 'ノウハウチェック機能', type: :system do
         visit know_hows_path
         expect do
           within "#know-how-#{know_how_first.id}" do
-            expect(page).not_to have_css '.text-muted'
+            expect(page).not_to have_css '.uncheck-color'
             find("a[href='#{know_how_progresses_path(know_how_first)}']").click
-            expect(page).to have_css '.text-muted'
+            expect(page).to have_css '.uncheck-color'
           end
         end.to change { user.progresses.count }.by(-1)
       end


### PR DESCRIPTION
close #191
  
## 実装内容
- 変数用のファイル`app/assets/stylesheets/_valiables.scss`を作成してカラーを定義(メンテナンス性を向上させるため)
```scss
$main: #A40000;
$dark-gray: #808080;
$light-gray: #EEEDEC;
$gold: #BAA877;
$silver: #A8A9A8;
$koppar: #947B60;
$bitter-orange: #A36A31;
```
- `bootstrap.scss`の`$theme-colors`に色を追加
  - Bootstrap の CSS は Sprockets で扱っているため、インクルードする前に変数を読み込むように設定
  ```scss
  @import 'valiables';
  $theme-colors: (
  	"main": $main,
    "dark-gray": $dark-gray,
    "light-gray": $light-gray,
    "bitter-orange": $bitter-orange
  );
  @import "bootstrap/scss/bootstrap";
  ```
- 既存のcssの`カラーコード`やjsファイルやビューでカラーを指定していた`class属性`を変数に置き換える
- ページネーションのcssを`application.scss`に移行
- ノウハウのシステムスペックでチェックの有無を検証しているclass属性を修正
- ドロップダウンのリストが`hover`,`active`状態での背景色の指定を削除してデフォルトで表示
  
## 動作確認
- [ ] `rubocop -A`を実行
- [ ] `bundle exec rails_best_practices .`を実行
- [ ] `bundle exec rspec spec/system`を実行してテストが通過することを確認