### PR TITLE
トップページのコンテナ幅を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,16 +59,14 @@ footer {
   }
 }
 
-.base-container {
-  margin: 0 auto;
-}
-
 .mw-sm {
   max-width: 576px;
+  margin: 0 auto;
 }
 
 .mw-xl {
   max-width: 1200px;
+  margin: 0 auto;
 }
 
 .alert-notice {

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -4,6 +4,15 @@
 
 @import 'valiables';
 
+.top-title {
+  font-size: 4rem;
+  font-weight: bold;
+}
+
+.sub-title {
+  font-size: 1.5rem;
+}
+
 .key-visual-left {
   min-height: 80vh;
   background-image: url("top_left_reverse.jpg");

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -4,6 +4,20 @@
 
 @import 'valiables';
 
+@media (max-width: 575.98px) {
+  .key-visual-center {
+    min-height: 80vh;
+    background-image: url("top_left_reverse.jpg");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    .key-visual-background {
+      background-color:rgba(255,255,255,0.3);
+      width: 100%;
+    }
+  }
+}
+
 .top-title {
   font-size: 4rem;
   font-weight: bold;
@@ -35,19 +49,6 @@
   background-position: right;
   background-repeat: no-repeat;
   background-size: contain;
-}
-
-@media (max-width: 575.98px) {
-  .key-visual-center {
-    min-height: 80vh;
-    background-image: url("top_left_reverse.jpg");
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    .key-visual-background {
-      background-color:rgba(255,255,255,0.3);
-    }
-  }
 }
 
 .headline {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,8 @@ module ApplicationHelper
   def max_width
     if devise_controller? || controller_name == 'inquiries'
       'mw-sm'
+    elsif controller_name == 'homes'
+      'px-0'
     else
       'mw-xl'
     end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -7,7 +7,7 @@
     <div class="key-visual-background">
       <div class="d-flex flex-column mx-md-auto h-100">
         <h1 class="top-title pt-5 pt-sm-0 px-4 my-sm-auto">MOKNOW</h1>
-        <h4 class="sub-title px-4 my-3 m-sm-0">理想の”おうち”で<br>素敵な”じかん”を<br>過ごそう</h4>
+        <h3 class="sub-title px-4 my-3 m-sm-0">理想の”おうち”で<br>素敵な”じかん”を<br>過ごそう</h3>
         <div class="key-image d-none d-sm-block mb-sm-auto"></div>
         <% unless user_signed_in? %>
           <div class="mx-md-auto px-4">
@@ -34,8 +34,8 @@
   <div class="row">
     <div class="col-12 col-sm-8">
       <h4>”MOKNOW”ってどんなアプリ？</h4>
-      <p class="pt-3">あなたが引っ越しの際やマイホームを建てた際に感じた ”成功・失敗エピソード” やあなたのおすすめの ”家具・家電” などをシェアするアプリです。</p>
-      <p>みんなの投稿やノウハウをチェックして引っ越しの際の”辞書”にしよう！</p>
+      <p class="pt-3">引っ越しやマイホーム建設の際に感じた ” 成功・失敗エピソード ” や、あなたのおすすめの ” 家具・家電 ” など、” おうち ” をシェアするアプリです。<br>みんなでシェアすることで理想のおうちや新しいアイデアの発見に繋がります。</p>
+      <p>みんなの投稿やノウハウをチェックしておうちの ” 辞書 ” にしよう！</p>
     </div>
     <div class="col-8 col-sm-4 col-md-3 mx-auto">
       <%= image_tag "feature.png", class: "img-fluid" %>
@@ -70,7 +70,7 @@
           </div>
           <div class="card-body p-3">
             <%= image_tag "timeline.png", class: "img-fluid" %>
-            <p class="card-text">自分のエピソードをシェアしてみよう！みんなの投稿をチェックすると理想の”おうち”が見つかります！</p>
+            <p class="card-text">みんなの投稿をチェックして理想のおうちを見つけてみよう！<br>気になる投稿を見つけたら ” いいね ” や ” マーク ” 機能を活用してみましょう！<br>あなたもおうちの投稿をしてみんなとシェアしてみませんか？</p>
           </div>
         <% end %>
       </div>
@@ -84,7 +84,7 @@
           </div>
           <div class="card-body p-3">
             <%= image_tag "myitem.png", class: "img-fluid" %>
-            <p class="card-text">”おうち”の家具・家電の寸法を記録しておこう！引っ越しの際の測り忘れの対策になります！</p>
+            <p class="card-text">おうちの ” 家具・家電 ” などを記録しておく事ができます！<br>今ある家具・家電などの種類やサイズが分からず、困ったことはありませんか？ 記録しておくことで迷わず簡単に確認する事ができ、購入や引っ越しなどの際の役に立ちます！</p>
           </div>
         <% end %>
       </div>
@@ -98,7 +98,7 @@
           </div>
           <div class="card-body p-3">
             <%= image_tag "about.png", class: "img-fluid" %>
-            <p class="card-text">引っ越しの際のノウハウをピックアップしているよ！チェックして”快適”な引っ越しをしましょう！</p>
+            <p class="card-text">引っ越しの際やっておくと良いことをピックアップしています！<br>準備するものや手順はノウハウ毎に確認する事ができます。<br>” ノウハウ ” をチェックをして快適な引っ越しをしましょう！</p>
           </div>
         <% end %>
       </div>
@@ -112,7 +112,7 @@
           </div>
           <div class="card-body p-3">
             <%= image_tag "data.png", class: "img-fluid" %>
-            <p class="card-text">アプリのデータの集計を誰でも見ることができるよ！”いいね”獲得数ランキングもチェックできます！</p>
+            <p class="card-text">人気の "タグ" や "カテゴリ" 、"いいね獲得数" などのランキングをチェックする事ができます！<br>人気の投稿を目指して、たくさんのいいねを獲得しランキング上位を目指しましょう！</p>
           </div>
         <% end %>
       </div>
@@ -120,7 +120,7 @@
   </div>
 </div>
 <div class="bg-light py-4">
-  <p class="text-center py-4">エピソードをシェアしてみよう！</p>
+  <p class="text-center py-4">さあ、あなたの "おうち" をシェアしてみよう！</p>
   <div class="d-flex justify-content-center">
     <div class="d-inline-flex flex-column">
       <% unless user_signed_in? %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -31,13 +31,13 @@
     <h2 class="m-0">Feature</h2>
     <p class="text-center text-muted">アプリについて</p>
   </div>
-  <div class="row w-100 m-0">
-    <div class="col-12 col-sm-8 px-0">
+  <div class="row">
+    <div class="col-12 col-sm-8">
       <h4>”MOKNOW”ってどんなアプリ？</h4>
       <p class="pt-3">あなたが引っ越しの際やマイホームを建てた際に感じた ”成功・失敗エピソード” やあなたのおすすめの ”家具・家電” などをシェアするアプリです。</p>
       <p>みんなの投稿やノウハウをチェックして引っ越しの際の”辞書”にしよう！</p>
     </div>
-    <div class="col-8 offset-2 col-sm-4 offset-sm-0 col-md-3 offset-md-1 px-0 mt-n4">
+    <div class="col-8 col-sm-4 col-md-3 mx-auto">
       <%= image_tag "feature.png", class: "img-fluid" %>
     </div>
   </div>
@@ -49,7 +49,7 @@
         <h2 class="m-0">Pick Up</h2>
         <p class="text-center text-muted">ピックアップ</p>
       </div>
-      <div class="row w-100 m-0 flex-nowrap overflow-auto">
+      <div class="row flex-nowrap overflow-auto">
         <%= render partial: "pick_up", collection: @posts, as: "post" %>
       </div>
     </div>
@@ -64,7 +64,7 @@
     <div class="col-12 col-sm-6 col-md-3 mb-4">
       <div class="card text-center h-100">
         <%= link_to posts_path, class: "text-reset" do %>
-          <div class="card-header p-3">
+          <div class="card-header px-0">
             <h3 class="card-title">Time Line</h3>
             <h6 class="card-subtitle">タイムライン</h6>
           </div>
@@ -78,7 +78,7 @@
     <div class="col-12 col-sm-6 col-md-3 mb-4">
       <div class="card text-center h-100">
         <%= link_to user_item_page, class: "text-reset" do %>
-          <div class="card-header p-3">
+          <div class="card-header px-0">
             <h3 class="card-title">My Item</h3>
             <h6 class="card-subtitle">マイアイテム</h6>
           </div>
@@ -92,7 +92,7 @@
     <div class="col-12 col-sm-6 col-md-3 mb-4">
       <div class="card text-center h-100">
         <%= link_to know_hows_path, class: "text-reset" do %>
-          <div class="card-header p-3">
+          <div class="card-header px-0">
             <h3 class="card-title">Know How</h3>
             <h6 class="card-subtitle">ノウハウ</h6>
           </div>
@@ -106,7 +106,7 @@
     <div class="col-12 col-sm-6 col-md-3 mb-4">
       <div class="card text-center h-100">
         <%= link_to graphs_path, class: "text-reset" do %>
-          <div class="card-header p-3">
+          <div class="card-header px-0">
             <h3 class="card-title">Data</h3>
             <p class="card-subtitle">データ</p>
           </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -4,8 +4,8 @@
   </div>
   <div class="col-12 col-sm-7 col-md-5 col-lg-4 text-right text-sm-left bg-light key-visual-center px-0">
     <div class="d-flex flex-column key-visual-background h-100">
-      <h1 class="display-4 font-weight-bold pt-5 pt-sm-0 px-4 my-sm-auto">MOKNOW</h1>
-      <h4 class="px-4 my-3 m-sm-0">理想の”おうち”で<br>素敵な”じかん”を<br>過ごそう</h4>
+      <h1 class="top-title font-weight-bold pt-5 pt-sm-0 px-4 my-sm-auto">MOKNOW</h1>
+      <h4 class="sub-title px-4 my-3 m-sm-0">理想の”おうち”で<br>素敵な”じかん”を<br>過ごそう</h4>
       <div class="key-image d-none d-sm-block mb-sm-auto"></div>
       <% unless user_signed_in? %>
         <div class="ml-auto ml-sm-0 px-4">

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row no-gutters">
   <div class="col-5 col-md-4 d-none d-sm-block p-0">
     <div class="key-visual-left"></div>
   </div>
@@ -21,24 +21,26 @@
   <div class="col-md-3 col-lg-4 d-none d-md-block p-0">
     <div class="key-visual-right"></div>
   </div>
-  <div class="col-12 p-4">
-    <div class="d-inline-flex flex-column headline pb-4">
-      <h2 class="m-0">Feature</h2>
-      <p class="text-center text-muted">アプリについて</p>
+</div>
+<div class="mw-xl px-3 py-4">
+  <div class="d-inline-flex flex-column headline pb-4">
+    <h2 class="m-0">Feature</h2>
+    <p class="text-center text-muted">アプリについて</p>
+  </div>
+  <div class="row w-100 m-0">
+    <div class="col-12 col-sm-8 px-0">
+      <h4>”MOKNOW”ってどんなアプリ？</h4>
+      <p class="pt-3">あなたが引っ越しの際やマイホームを建てた際に感じた ”成功・失敗エピソード” やあなたのおすすめの ”家具・家電” などをシェアするアプリです。</p>
+      <p>みんなの投稿やノウハウをチェックして引っ越しの際の”辞書”にしよう！</p>
     </div>
-    <div class="row w-100 m-0">
-      <div class="col-12 col-sm-8 px-0">
-        <h4>”MOKNOW”ってどんなアプリ？</h4>
-        <p class="pt-3">あなたが引っ越しの際やマイホームを建てた際に感じた ”成功・失敗エピソード” やあなたのおすすめの ”家具・家電” などをシェアするアプリです。</p>
-        <p>みんなの投稿やノウハウをチェックして引っ越しの際の”辞書”にしよう！</p>
-      </div>
-      <div class="col-8 offset-2 col-sm-4 offset-sm-0 col-md-3 offset-md-1 px-0 mt-n4">
-        <%= image_tag "feature.png", class: "img-fluid" %>
-      </div>
+    <div class="col-8 offset-2 col-sm-4 offset-sm-0 col-md-3 offset-md-1 px-0 mt-n4">
+      <%= image_tag "feature.png", class: "img-fluid" %>
     </div>
   </div>
-  <% if @posts.present? %>
-    <div class="col-12 bg-light p-4">
+</div>
+<% if @posts.present? %>
+  <div class="bg-light py-4">
+    <div class="mw-xl px-3">
       <div class="d-inline-flex flex-column headline pb-4">
         <h2 class="m-0">Pick Up</h2>
         <p class="text-center text-muted">ピックアップ</p>
@@ -47,81 +49,81 @@
         <%= render partial: "pick_up", collection: @posts, as: "post" %>
       </div>
     </div>
-  <% end %>
-  <div class="col-12 p-4">
-    <div class="d-inline-flex flex-column headline pb-4">
-      <h2 class="m-0">Function</h2>
-      <p class="text-center text-muted">機能</p>
+  </div>
+<% end %>
+<div class="mw-xl px-3 py-4">
+  <div class="d-inline-flex flex-column headline pb-4">
+    <h2 class="m-0">Function</h2>
+    <p class="text-center text-muted">機能</p>
+  </div>
+  <div class="row">
+    <div class="col-12 col-sm-6 col-md-3 mb-4">
+      <div class="card text-center h-100">
+        <%= link_to posts_path, class: "text-reset" do %>
+          <div class="card-header p-3">
+            <h3 class="card-title">Time Line</h3>
+            <h6 class="card-subtitle">タイムライン</h6>
+          </div>
+          <div class="card-body p-3">
+            <%= image_tag "timeline.png", class: "img-fluid" %>
+            <p class="card-text">自分のエピソードをシェアしてみよう！みんなの投稿をチェックすると理想の”おうち”が見つかります！</p>
+          </div>
+        <% end %>
+      </div>
     </div>
-    <div class="row">
-      <div class="col-12 col-sm-6 col-md-3 mb-4">
-        <div class="card text-center h-100">
-          <%= link_to posts_path, class: "text-reset" do %>
-            <div class="card-header p-3">
-              <h3 class="card-title">Time Line</h3>
-              <h6 class="card-subtitle">タイムライン</h6>
-            </div>
-            <div class="card-body p-3">
-              <%= image_tag "timeline.png", class: "img-fluid" %>
-              <p class="card-text">自分のエピソードをシェアしてみよう！みんなの投稿をチェックすると理想の”おうち”が見つかります！</p>
-            </div>
-          <% end %>
-        </div>
+    <div class="col-12 col-sm-6 col-md-3 mb-4">
+      <div class="card text-center h-100">
+        <%= link_to user_item_page, class: "text-reset" do %>
+          <div class="card-header p-3">
+            <h3 class="card-title">My Item</h3>
+            <h6 class="card-subtitle">マイアイテム</h6>
+          </div>
+          <div class="card-body p-3">
+            <%= image_tag "myitem.png", class: "img-fluid" %>
+            <p class="card-text">”おうち”の家具・家電の寸法を記録しておこう！引っ越しの際の測り忘れの対策になります！</p>
+          </div>
+        <% end %>
       </div>
-      <div class="col-12 col-sm-6 col-md-3 mb-4">
-        <div class="card text-center h-100">
-          <%= link_to user_item_page, class: "text-reset" do %>
-            <div class="card-header p-3">
-              <h3 class="card-title">My Item</h3>
-              <h6 class="card-subtitle">マイアイテム</h6>
-            </div>
-            <div class="card-body p-3">
-              <%= image_tag "myitem.png", class: "img-fluid" %>
-              <p class="card-text">”おうち”の家具・家電の寸法を記録しておこう！引っ越しの際の測り忘れの対策になります！</p>
-            </div>
-          <% end %>
-        </div>
+    </div>
+    <div class="col-12 col-sm-6 col-md-3 mb-4">
+      <div class="card text-center h-100">
+        <%= link_to know_hows_path, class: "text-reset" do %>
+          <div class="card-header p-3">
+            <h3 class="card-title">Know How</h3>
+            <h6 class="card-subtitle">ノウハウ</h6>
+          </div>
+          <div class="card-body p-3">
+            <%= image_tag "about.png", class: "img-fluid" %>
+            <p class="card-text">引っ越しの際のノウハウをピックアップしているよ！チェックして”快適”な引っ越しをしましょう！</p>
+          </div>
+        <% end %>
       </div>
-      <div class="col-12 col-sm-6 col-md-3 mb-4">
-        <div class="card text-center h-100">
-          <%= link_to know_hows_path, class: "text-reset" do %>
-            <div class="card-header p-3">
-              <h3 class="card-title">Know How</h3>
-              <h6 class="card-subtitle">ノウハウ</h6>
-            </div>
-            <div class="card-body p-3">
-              <%= image_tag "about.png", class: "img-fluid" %>
-              <p class="card-text">引っ越しの際のノウハウをピックアップしているよ！チェックして”快適”な引っ越しをしましょう！</p>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <div class="col-12 col-sm-6 col-md-3 mb-4">
-        <div class="card text-center h-100">
-          <%= link_to graphs_path, class: "text-reset" do %>
-            <div class="card-header p-3">
-              <h3 class="card-title">Data</h3>
-              <p class="card-subtitle">データ</p>
-            </div>
-            <div class="card-body p-3">
-              <%= image_tag "data.png", class: "img-fluid" %>
-              <p class="card-text">アプリのデータの集計を誰でも見ることができるよ！”いいね”獲得数ランキングもチェックできます！</p>
-            </div>
-          <% end %>
-        </div>
+    </div>
+    <div class="col-12 col-sm-6 col-md-3 mb-4">
+      <div class="card text-center h-100">
+        <%= link_to graphs_path, class: "text-reset" do %>
+          <div class="card-header p-3">
+            <h3 class="card-title">Data</h3>
+            <p class="card-subtitle">データ</p>
+          </div>
+          <div class="card-body p-3">
+            <%= image_tag "data.png", class: "img-fluid" %>
+            <p class="card-text">アプリのデータの集計を誰でも見ることができるよ！”いいね”獲得数ランキングもチェックできます！</p>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>
-  <div class="col-12 bg-light p-4">
-    <p class="text-center py-4">エピソードをシェアしてみよう！</p>
-    <div class="d-flex justify-content-center">
-      <div class="d-inline-flex flex-column">
-        <% unless user_signed_in? %>
-          <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
-          <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
-        <% end %>
-      </div>
+</div>
+<div class="bg-light py-4">
+  <p class="text-center py-4">エピソードをシェアしてみよう！</p>
+  <div class="d-flex justify-content-center">
+    <div class="d-inline-flex flex-column">
+      <% unless user_signed_in? %>
+        <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
+        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,24 +1,28 @@
 <div class="row no-gutters">
-  <div class="col-5 col-md-4 d-none d-sm-block p-0">
+  <div class="col d-none d-sm-block p-0">
     <div class="key-visual-left"></div>
   </div>
-  <div class="col-12 col-sm-7 col-md-5 col-lg-4 text-right text-sm-left bg-light key-visual-center px-0">
-    <div class="d-flex flex-column key-visual-background h-100">
-      <h1 class="top-title font-weight-bold pt-5 pt-sm-0 px-4 my-sm-auto">MOKNOW</h1>
-      <h4 class="sub-title px-4 my-3 m-sm-0">理想の”おうち”で<br>素敵な”じかん”を<br>過ごそう</h4>
-      <div class="key-image d-none d-sm-block mb-sm-auto"></div>
-      <% unless user_signed_in? %>
-        <div class="ml-auto ml-sm-0 px-4">
-          <div class="d-inline-flex flex-column">
-            <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
-            <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
+  <div class="col col-sm-7 col-md px-0">
+    <div class="d-flex justify-content-end justify-content-sm-start justify-content-md-center text-right text-sm-left bg-light h-100 key-visual-center">
+    <div class="key-visual-background">
+      <div class="d-flex flex-column mx-md-auto h-100">
+        <h1 class="top-title pt-5 pt-sm-0 px-4 my-sm-auto">MOKNOW</h1>
+        <h4 class="sub-title px-4 my-3 m-sm-0">理想の”おうち”で<br>素敵な”じかん”を<br>過ごそう</h4>
+        <div class="key-image d-none d-sm-block mb-sm-auto"></div>
+        <% unless user_signed_in? %>
+          <div class="mx-md-auto px-4">
+            <div class="d-inline-flex flex-column">
+              <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
+              <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
+              <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
+            </div>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
+    </div>
     </div>
   </div>
-  <div class="col-md-3 col-lg-4 d-none d-md-block p-0">
+  <div class="col d-none d-md-block p-0">
     <div class="key-visual-right"></div>
   </div>
 </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -120,14 +120,20 @@
   </div>
 </div>
 <div class="bg-light py-4">
-  <p class="text-center py-4">さあ、あなたの "おうち" をシェアしてみよう！</p>
-  <div class="d-flex justify-content-center">
-    <div class="d-inline-flex flex-column">
-      <% unless user_signed_in? %>
-        <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
-        <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
-      <% end %>
+  <div class="mb-5">
+    <p class="text-center py-4">さあ、あなたの "おうち" をシェアしてみよう！</p>
+    <div class="d-flex justify-content-center">
+      <div class="d-inline-flex flex-column">
+        <% if user_signed_in? %>
+          <button type="button" class="btn btn-main" data-toggle="modal" data-target="#new-modal">
+            <i class="fas fa-plus-square"></i> 投稿する
+          </button>
+        <% else %>
+          <%= link_to "会員登録", new_user_registration_path, class: "btn btn-main mb-3" %>
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-dark-gray mb-3" %>
+          <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: "btn btn-bitter-orange mb-3 guest-login" %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/know_hows/_show.html.erb
+++ b/app/views/know_hows/_show.html.erb
@@ -8,9 +8,10 @@
         </button>
       </div>
       <div class="modal-body">
-      <p id="know-how-modal-content"></p>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-dark-gray" data-dismiss="modal">閉じる</button>
+        <p id="know-how-modal-content"></p>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-dark-gray" data-dismiss="modal">閉じる</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
     <div id="flash-messages">
       <%= render 'layouts/flash_messages' %>
     </div>
-    <div class='base-container px-3 <%= max_width %>'>
+    <div class='container-fluid <%= max_width %>'>
       <%= yield %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,12 +15,12 @@
     <%= render 'shared/header_bottom' %>
     <%= render 'shared/modal', action: 'new', title: '新規登録' %>
     <%= render 'shared/modal', action: 'search', title: '検索' %>
-    <%= render 'shared/footer' %>
     <div id="flash-messages">
       <%= render 'layouts/flash_messages' %>
     </div>
     <div class='container-fluid <%= max_width %>'>
       <%= yield %>
     </div>
+    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/spec/models/progress_spec.rb
+++ b/spec/models/progress_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Progress, type: :model do
   describe 'バリデーション' do
     subject { progress.valid? }
 
+    before do
+      FactoryBot.rewind_sequences
+    end
+
     context 'データが条件を満たすとき' do
       let(:progress) { build(:progress) }
       it '保存できること' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe User, type: :model do
 
     let(:user) { create(:user) }
     before do
+      FactoryBot.rewind_sequences
       create(:like)
       create(:mark)
       create(:comment)


### PR DESCRIPTION
close #193

## 実装内容
- トップページのコンテナ幅を全幅(常に100%)に修正
  - トップページのみ全幅になるようにヘルパーメソッドに条件を追加
- トップページでのコンテンツ(Feature, PickUp, Function)幅を`最大1200px`に設定
  - cssの`.mw-xl`を設定
- トップページ下部のログイン関連のボタンを画面幅が`768px`以上の場合、親要素の中央になるように修正
- トップページのタイトル・サブタイトルにclass属性を追加してフォントサイズを設定
  - タイトルは`4rem`で設定
  - サブタイトルは`1.5rem`で設定
- `Feature`, `PickUp`, `Function`の各コンテンツの`padding`, `margin`を修正
- トップページのFeature・Functionの説明文を修正
- ログイン後はトップページ下部に投稿ボタンを表示するように設定
- フッターのレイアウトが崩れていたため修正
- progressモデルのテスト実行時にシーケンスが巻き戻されるように設定
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exec rspec spec/system spec/models`を実行