### PR TITLE
環境毎にseedsの処理を分岐

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,7 @@ items = RakutenWebService::Ichiba::Product.search(keyword: 'ダイソン', hits:
 # 管理者ユーザー用メールアドレス
 admin_email = 'admin@example.com'
 
-%w[users posts photos tags categories post_tags post_categories likes marks admin_users know_hows items].each do |table_name|
+%w[tags categories admin_users know_hows].each do |table_name|
   ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
 end
 
@@ -41,51 +41,6 @@ puts 'タグの初期データインポートに成功しました。'
 
 categories.each { |category| Category.create!(name: category) }
 puts 'カテゴリーの初期データインポートに成功しました。'
-
-test_user = User.find_or_create_by!(email: email) do |user|
-  user.name = name
-  user.password = password
-  user.age = age
-  user.address = address
-  user.household = household
-  puts 'テストユーザーの初期データインポートに成功しました。'
-end
-
-items.each do |item|
-  Item.create!(
-    name: item['productName'],
-    genre: item['genreName'],
-    remote_image_url: item['mediumImageUrl'],
-    user_id: test_user.id
-  )
-end
-puts 'テストユーザーアイテムの初期データ 30 件のインポートに成功しました。'
-
-1000.times do
-  User.create!(
-    name: Faker::Name.name,
-    email: Faker::Internet.email,
-    password: Faker::Internet.password,
-    age: age,
-    address: address,
-    household: household
-  )
-end
-puts 'ユーザーの初期データ 1000 件のインポートに成功しました。'
-
-1000.times do
-  post = Post.create!(
-    content: Faker::Lorem.paragraph(sentence_count: 100),
-    user_id: rand(1..1000)
-  )
-  post.photos.create!(image: image)
-  post.post_tags.create!(tag_id: rand(1..12))
-  post.post_categories.create!(category_id: rand(1..6))
-  post.comments.create!(content: content, user_id: rand(1..1000))
-  post.likes.create!(user_id: rand(1..1000))
-  post.marks.create!(user_id: rand(1..1000))
-end
-puts '投稿の初期データ 1000 件のインポートに成功しました。'
 
 AdminUser.find_or_create_by!(email: admin_email) do |admin_user|
   admin_user.password = password
@@ -100,3 +55,55 @@ CSV.foreach('db/csv_data/know_how_data.csv', headers: true) do |row|
   )
 end
 puts 'ノウハウの初期データインポートに成功しました。'
+
+# 開発環境用の初期データ
+if Rails.env.development?
+  %w[users posts photos post_tags post_categories likes marks items].each do |table_name|
+    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name} RESTART IDENTITY CASCADE")
+  end
+
+  test_user = User.find_or_create_by!(email: email) do |user|
+    user.name = name
+    user.password = password
+    user.age = age
+    user.address = address
+    user.household = household
+    puts 'テストユーザーの初期データインポートに成功しました。'
+  end
+
+  items.each do |item|
+    Item.create!(
+      name: item['productName'],
+      genre: item['genreName'],
+      remote_image_url: item['mediumImageUrl'],
+      user_id: test_user.id
+    )
+  end
+  puts 'テストユーザーアイテムの初期データ 30 件のインポートに成功しました。'
+
+  1000.times do
+    User.create!(
+      name: Faker::Name.name,
+      email: Faker::Internet.email,
+      password: Faker::Internet.password,
+      age: age,
+      address: address,
+      household: household
+    )
+  end
+  puts 'ユーザーの初期データ 1000 件のインポートに成功しました。'
+
+  1000.times do
+    post = Post.create!(
+      content: Faker::Lorem.paragraph(sentence_count: 100),
+      user_id: rand(1..1000)
+    )
+    post.photos.create!(image: image)
+    post.post_tags.create!(tag_id: rand(1..12))
+    post.post_categories.create!(category_id: rand(1..6))
+    post.comments.create!(content: content, user_id: rand(1..1000))
+    post.likes.create!(user_id: rand(1..1000))
+    post.marks.create!(user_id: rand(1..1000))
+  end
+  puts '投稿の初期データ 1000 件のインポートに成功しました。'
+end


### PR DESCRIPTION
close #197
  
## 実装内容
- ユーザー・投稿・アイテムの初期データ作成には Faker を使用しているかつ本番環境では必要ないデータなので開発環境のみで挿入するように設定
  
## 動作確認
- [ ] `rubocop -A`を実行
- [ ] `bundle exec rails_best_practics .`を実行
- [ ] 本番環境で`タグ`, `カテゴリ`, `管理者`, `ノウハウ`の初期データが挿入されていることを確認