### PR TITLE
ログイン前後のナビバー上部に表示するリンクを修正

### DIFF
--- a/app/views/shared/_header_bottom.html.erb
+++ b/app/views/shared/_header_bottom.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
 <nav class="navbar navbar-expand navbar-light bg-light fixed-bottom d-sm-none">
-  <div class="navbar-nav w-100 justify-content-between">
+  <div class="navbar-nav w-100 justify-content-around">
     <button type="button" class="btn btn-main" data-toggle="modal" data-target="#new-modal">
       <i class="fas fa-plus-square"></i>
     </button>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -44,12 +44,6 @@
         <%= link_to new_user_session_path, class: "nav-item nav-link" do %>
           <i class="fas fa-sign-in-alt"></i> ログイン
         <% end %>
-        <%= link_to graphs_path, class: "nav-item nav-link" do %>
-          <i class="fas fa-chart-pie"></i> データ
-        <% end %>
-        <%= link_to "#", class: "nav-item nav-link" do %>
-          <i class="fas fa-book"></i> ノウハウ
-        <% end %>
         <%= link_to inquiries_path, class: "nav-item nav-link d-block d-sm-none" do %>
           <i class="fas fa-envelope"></i> お問い合わせ
         <% end %>

--- a/app/views/shared/_header_top.html.erb
+++ b/app/views/shared/_header_top.html.erb
@@ -1,19 +1,23 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
   <%= link_to "MOKNOW", root_path, class: "navbar-brand" %>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-
-  <div class="collapse navbar-collapse" id="navbarNav">
-    <% if user_signed_in? %>
+  <% if user_signed_in? %>
+    <div class="ml-auto mr-3">
       <button type="button" class="btn btn-main d-sm-inline d-none" data-toggle="modal" data-target="#new-modal">
         <i class="fas fa-plus-square"></i> 投稿する
       </button>
       <button type="button" class="btn btn-outline-dark-gray d-sm-inline d-none" data-toggle="modal" data-target="#search-modal">
         <i class="fas fa-search"></i> 検索する
       </button>
-      <%# 要素を右寄せで配置 %>
-      <div class="navbar-nav ml-auto">
+    </div>
+  <% end %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <%# 要素を右寄せで配置 %>
+    <div class="navbar-nav ml-auto">
+      <% if user_signed_in? %>
         <%= link_to graphs_path, class: "nav-item nav-link" do %>
           <i class="fas fa-chart-pie"></i> データ
         <% end %>
@@ -29,12 +33,7 @@
         <%= link_to user_path(current_user.id), class: "nav-item nav-link d-sm-block d-none" do %>
           <i class="fas fa-user"></i> マイページ
         <% end %>
-        <%= link_to inquiries_path, class: "nav-item nav-link d-block d-sm-none" do %>
-          <i class="fas fa-envelope"></i> お問い合わせ
-        <% end %>
-      </div>
-    <% else %>
-      <div class="navbar-nav ml-auto">
+      <% else %>
         <%= link_to users_guest_sign_in_path, method: :post, class: "nav-item nav-link guest-login" do %>
           <i class="fas fa-id-card-alt"></i> ゲストログイン
         <% end %>
@@ -44,10 +43,16 @@
         <%= link_to new_user_session_path, class: "nav-item nav-link" do %>
           <i class="fas fa-sign-in-alt"></i> ログイン
         <% end %>
-        <%= link_to inquiries_path, class: "nav-item nav-link d-block d-sm-none" do %>
-          <i class="fas fa-envelope"></i> お問い合わせ
-        <% end %>
-      </div>
-    <% end %>
+      <% end %>
+      <%= link_to inquiries_path, class: "nav-item nav-link d-block d-sm-none" do %>
+        <i class="fas fa-envelope"></i> お問い合わせ
+      <% end %>
+      <%= link_to page_path('terms_of_use'), class: "nav-item nav-link d-block d-sm-none" do %>
+        <i class="fas fa-book"></i> 利用規約
+      <% end %>
+      <%= link_to page_path('privacy_policy'), class: "nav-item nav-link d-block d-sm-none" do %>
+        <i class="fas fa-key"></i> プライバシーポリシー
+      <% end %>
+    </div>
   </div>
 </nav>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -24,16 +24,6 @@
               <i class="fas fa-couch"></i>
               <span class="pl-2">マイアイテム</span>
             <% end %>
-            <div class="d-sm-none">
-              <%= link_to page_path('terms_of_use'), class: "dropdown-item text-left" do %>
-                <i class="fas fa-book"></i>
-                <span class="pl-2">利用規約</span>
-              <% end %>
-              <%= link_to page_path('privacy_policy'), class: "dropdown-item text-left" do %>
-                <i class="fas fa-key"></i>
-                <span class="pl-2">プライバシーポリシー</span>
-              <% end %>
-            </div>
           </div>
         </div>
       <% end %>

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe '投稿機能', type: :system do
     context '入力内容が条件を満たすとき' do
       it '新しい投稿が作成されること', js: true do
         expect do
-          find('.navbar-toggler').click
-          within '.navbar-collapse' do
+          within '.navbar' do
             click_on '投稿する'
           end
           fill_in 'キャプション', with: post.content
@@ -64,8 +63,7 @@ RSpec.describe '投稿機能', type: :system do
     context '未入力の項目があるとき' do
       it 'エラーメッセージが表示され、新しい投稿が作成されないこと', js: true do
         expect do
-          find('.navbar-toggler').click
-          within '.navbar-collapse' do
+          within '.navbar' do
             click_on '投稿する'
           end
           expect(page).to have_button '投稿する', disabled: true
@@ -81,8 +79,7 @@ RSpec.describe '投稿機能', type: :system do
     context 'タグ・カテゴリが3つ以上選択されているとき' do
       it 'エラーメッセージが表示され、新しい投稿が作成されないこと', js: true do
         expect do
-          find('.navbar-toggler').click
-          within '.navbar-collapse' do
+          within '.navbar' do
             click_on '投稿する'
           end
           fill_in 'キャプション', with: post.content

--- a/spec/system/searches_spec.rb
+++ b/spec/system/searches_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe '投稿検索機能', type: :system do
     context '検索条件を設定した場合' do
       let(:post) { Post.first }
       it 'その条件を含む投稿が表示されること', js: true do
-        find('.navbar-toggler').click
-        within '.navbar-collapse' do
+        within '.navbar' do
           click_on '検索する'
         end
         within '.modal-content' do
@@ -40,8 +39,7 @@ RSpec.describe '投稿検索機能', type: :system do
     context '条件を設定しない場合' do
       let(:post_last) { Post.last }
       it '投稿日時が降順で表示されること', js: true do
-        find('.navbar-toggler').click
-        within '.navbar-collapse' do
+        within '.navbar' do
           click_on '検索する'
         end
         within '.modal-content' do
@@ -57,8 +55,7 @@ RSpec.describe '投稿検索機能', type: :system do
 
     context '検索条件が一致する投稿がない場合' do
       it '投稿が表示されないこと', js: true do
-        find('.navbar-toggler').click
-        within '.navbar-collapse' do
+        within '.navbar' do
           click_on '検索する'
         end
         within '.modal-content' do
@@ -72,8 +69,7 @@ RSpec.describe '投稿検索機能', type: :system do
 
     context '検索モーダルでリセットボタンを押下したとき' do
       it '設定済みの検索条件が一括リセットされること', js: true do
-        find('.navbar-toggler').click
-        within '.navbar-collapse' do
+        within '.navbar' do
           click_on '検索する'
         end
         within '.modal-content' do


### PR DESCRIPTION
close #198
  
## 実装内容
- ログイン前は`データ`, `ノウハウ`のリンクを表示しないように修正
- ログイン後の画面幅が sm 以下の場合、上部ナビバーに`利用規約`, `プライバシーポリシー`のリンクを追加で表示
- ログイン後の画面幅が sm 以下の場合、マイページのドロップダウンメニューに表示していた`利用規約`, `プライバシーポリシー`のリンクを削除
- `投稿`・`検索`のボタンをナビバーの`.collapse`の外に配置して折り畳まれないように修正
- `お問い合わせ`・`利用規約`・`プライバシーポリシー`のリンクはユーザーのログイン状態に関係なく画面が`sm以下`の場合は常に表示するように修正
  
## 動作確認
- [x] `rubocop -A`を実行
- [x] `bundle exec rails_best_practices .`を実行
- [x] `bundle exc rspec spec/forms spec/models spec/system`を実行